### PR TITLE
Add CompactionFilter, RepairDb, Flush and GetLiveFilesMetadata

### DIFF
--- a/csharp/src/CompactionFilter.cs
+++ b/csharp/src/CompactionFilter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace RocksDbSharp
+{
+    public class CompactionFilter
+    {
+        public IntPtr Handle;
+        private readonly NameDelegate getNameDelegate;
+        private readonly FilterDelegate filterDelegate;
+        private readonly DestructorDelegate destroyDelegate;
+
+        public CompactionFilter(NameDelegate nameDelegate, 
+                                FilterDelegate filterDelegate, 
+                                DestructorDelegate destroyDelegate, 
+                                IntPtr state)
+        {
+            this.getNameDelegate = nameDelegate;
+            this.filterDelegate = filterDelegate;
+            this.destroyDelegate = destroyDelegate;
+            Handle = Native.Instance.rocksdb_compactionfilter_create(state, destroyDelegate, filterDelegate, getNameDelegate);
+        }        
+    }
+}

--- a/csharp/src/FlushOptions.cs
+++ b/csharp/src/FlushOptions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RocksDbSharp
+{
+    public class FlushOptions: OptionsHandle
+    {
+        public FlushOptions()
+        {
+            Native.Instance.rocksdb_flushoptions_create();
+        }
+
+        public FlushOptions SetWaitForFlush(bool waitForFlush)
+        {
+            Native.Instance.rocksdb_flushoptions_set_wait(Handle, waitForFlush);
+            return this;
+        }
+    }
+}

--- a/csharp/src/LiveFilesMetadata.cs
+++ b/csharp/src/LiveFilesMetadata.cs
@@ -1,0 +1,23 @@
+﻿namespace RocksDbSharp
+{
+    public class LiveFileMetadata
+    {
+        public FileMetadata FileMetadata;
+        public FileDataMetadata FileDataMetadata;
+    }   
+
+    public class FileMetadata
+    {
+        public string FileName;
+        public int FileLevel;
+        public ulong FileSize;
+    }
+
+    public class FileDataMetadata
+    {
+        public string SmallestKeyInFile;
+        public string LargestKeyInFile;
+        public ulong NumEntriesInFile;
+        public ulong NumDeletionsInFile;
+    }
+}

--- a/csharp/src/RocksDb.cs
+++ b/csharp/src/RocksDb.cs
@@ -404,5 +404,120 @@ namespace RocksDbSharp
 
             CompactRange(start is null ? null : encoding.GetBytes(start), limit is null ? null : encoding.GetBytes(limit), cf);
         }
+
+        public void Flush(FlushOptions flushOptions)
+        {
+            Native.Instance.rocksdb_flush(Handle, flushOptions.Handle);
+        }
+
+
+        /// <summary>
+        /// Returns metadata about the file and data in the file. 
+        /// </summary>
+        /// <param name="populateFileMetadataOnly">setting it to true only populates FileName, 
+        /// Filesize and filelevel; By default it is false</param>
+        /// <returns><c>LiveFilesMetadata</c> or null in case of failure</returns>
+        public List<LiveFileMetadata> GetLiveFilesMetadata(bool populateFileMetadataOnly=false)
+        {
+            IntPtr buffer = Native.Instance.rocksdb_livefiles(Handle);
+            if (buffer == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            try
+            {
+                List<LiveFileMetadata> filesMetadata = new List<LiveFileMetadata>();
+
+                int fileCount = Native.Instance.rocksdb_livefiles_count(buffer);
+                for (int index = 0; index < fileCount; index++)
+                {
+                    LiveFileMetadata liveFileMetadata = new LiveFileMetadata();
+
+                    FileMetadata metadata = new FileMetadata();
+                    IntPtr fileMetadata = Native.Instance.rocksdb_livefiles_name(buffer, index);
+                    string fileName = Marshal.PtrToStringAnsi(fileMetadata);
+
+                    int level = Native.Instance.rocksdb_livefiles_level(buffer, index);
+
+                    UIntPtr fS = Native.Instance.rocksdb_livefiles_size(buffer, index);
+                    ulong fileSize = fS.ToUInt64();
+
+                    metadata.FileName = fileName;
+                    metadata.FileLevel = level;
+                    metadata.FileSize = fileSize;
+
+                    liveFileMetadata.FileMetadata = metadata;
+
+                    if (!populateFileMetadataOnly)
+                    {
+                        FileDataMetadata fileDataMetadata = new FileDataMetadata();
+                        var smallestKeyPtr = Native.Instance.rocksdb_livefiles_smallestkey(buffer, 
+                                                                                           index, 
+                                                                         out var smallestKeySize);
+                        string smallestKey = Marshal.PtrToStringAnsi(smallestKeyPtr);
+
+                        var largestKeyPtr = Native.Instance.rocksdb_livefiles_largestkey(buffer, 
+                                                                                          index,
+                                                                         out var largestKeySize);
+                        string largestKey = Marshal.PtrToStringAnsi(largestKeyPtr);
+
+                        ulong entries = Native.Instance.rocksdb_livefiles_entries(buffer, index);
+                        ulong deletions = Native.Instance.rocksdb_livefiles_deletions(buffer, index);
+
+                        fileDataMetadata.SmallestKeyInFile = smallestKey;
+                        fileDataMetadata.LargestKeyInFile = largestKey;
+                        fileDataMetadata.NumEntriesInFile = entries;
+                        fileDataMetadata.NumDeletionsInFile = deletions;
+
+                        liveFileMetadata.FileDataMetadata = fileDataMetadata;
+                    }
+
+                    filesMetadata.Add(liveFileMetadata);
+                }           
+                
+                return filesMetadata;
+            }
+            finally
+            {
+                Native.Instance.rocksdb_livefiles_destroy(buffer);
+                buffer = IntPtr.Zero;
+            }
+        }
+
+        /// <summary>
+        /// Lean API to just get Live file names. 
+        /// Refer to GetLiveFilesMetadata() for the complete metadata
+        /// </summary>
+        /// <returns></returns>
+        public List<string> GetLiveFileNames()
+        {
+            IntPtr buffer = Native.Instance.rocksdb_livefiles(Handle);
+            if (buffer == IntPtr.Zero)
+            {
+                return new List<string>();
+            }
+
+            try
+            {
+                List<string> liveFiles = new List<string>();
+
+                int fileCount = Native.Instance.rocksdb_livefiles_count(buffer);
+
+                for (int index = 0; index < fileCount; index++)
+                {
+                    IntPtr fileMetadata = Native.Instance.rocksdb_livefiles_name(buffer, index);
+                    string fileName = Marshal.PtrToStringAnsi(fileMetadata);
+                    liveFiles.Add(fileName);
+                }
+                
+                return liveFiles;
+            }
+            finally
+            {
+                Native.Instance.rocksdb_livefiles_destroy(buffer);
+                buffer = IntPtr.Zero;
+            }
+        }        
     }
 }


### PR DESCRIPTION
1. Add support to specify delegates required by CompactionFilter.
2. Add Flush and FlushOptions to be able to do on-demand flush
3. Add RepairDb to be able to ingest sstfiles written by other rocksdb instances
4. Add methods to retrieve and parse LiveFiles Metadata