### PR TITLE
Span key for Iterator Seek / SeekForPrev

### DIFF
--- a/csharp/src/Iterator.cs
+++ b/csharp/src/Iterator.cs
@@ -94,6 +94,15 @@ namespace RocksDbSharp
             return this;
         }
 
+        public unsafe Iterator Seek(ReadOnlySpan<byte> key)
+        {
+            fixed (byte* keyPtr = key)
+            {
+                Native.Instance.rocksdb_iter_seek(handle, keyPtr, (UIntPtr)key.Length);
+                return this;
+            }
+        }
+
         public unsafe Iterator SeekForPrev(byte* key, ulong klen)
         {
             Native.Instance.rocksdb_iter_seek_for_prev(handle, key, (UIntPtr)klen);
@@ -116,6 +125,15 @@ namespace RocksDbSharp
         {
             Native.Instance.rocksdb_iter_seek_for_prev(handle, key);
             return this;
+        }
+
+        public unsafe Iterator SeekForPrev(ReadOnlySpan<byte> key)
+        {
+            fixed (byte* keyPtr = key)
+            {
+                Native.Instance.rocksdb_iter_seek_for_prev(handle, keyPtr, (UIntPtr)key.Length);
+                return this;
+            }
         }
 
         public Iterator Next()


### PR DESCRIPTION
Adds `Iterator.Seek(ReadOnlySpan<byte> key)` and `Iterator.SeekForPrev(ReadOnlySpan<byte> key)` overloads