### PR TITLE
add PutVector

### DIFF
--- a/csharp/src/WriteBatch.cs
+++ b/csharp/src/WriteBatch.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -157,6 +159,137 @@ namespace RocksDbSharp
                 }
             }
             return this;
+        }
+
+        public WriteBatch PutVector(ColumnFamilyHandle columnFamily, ReadOnlyMemory<byte> key, params ReadOnlyMemory<byte>[] values)
+        {
+            var pool = ArrayPool<ReadOnlyMemory<byte>>.Shared;
+            var keys = pool.Rent(1);
+            try
+            {
+                keys[0] = key;
+                PutVector(columnFamily, keys.AsSpan(0, 1), values);
+                return this;
+            }
+            finally
+            {
+                pool.Return(keys);
+            }
+        }
+
+        public WriteBatch PutVector(ReadOnlyMemory<byte> key, params ReadOnlyMemory<byte>[] values)
+        {
+            var pool = ArrayPool<ReadOnlyMemory<byte>>.Shared;
+            var keys = pool.Rent(1);
+            try
+            {
+                keys[0] = key;
+                PutVector(keys.AsSpan(0, 1), values);
+                return this;
+            }
+            finally
+            {
+                pool.Return(keys);
+            }
+        }
+
+        public WriteBatch PutVector(ReadOnlySpan<ReadOnlyMemory<byte>> keys, ReadOnlySpan<ReadOnlyMemory<byte>> values)
+        {
+            return PutVector(null, keys, values);
+        }
+
+        public unsafe WriteBatch PutVector(ColumnFamilyHandle columnFamily, ReadOnlySpan<ReadOnlyMemory<byte>> keys, ReadOnlySpan<ReadOnlyMemory<byte>> values)
+        {
+            var intPtrPool = ArrayPool<IntPtr>.Shared;
+            var uintPtrPool = ArrayPool<UIntPtr>.Shared;
+            IntPtr[] keysListArray = null, valuesListArray = null;
+            UIntPtr[] keysListSizesArray = null, valuesListSizesArray = null;
+
+            try
+            {
+                var keysLength = keys.Length;
+                (keysListArray, keysListSizesArray) = keysLength < 256 
+                    ? (null, null)
+                    : (intPtrPool.Rent(keysLength), uintPtrPool.Rent(keysLength));
+                Span<IntPtr> keysList = keysLength < 256 
+                    ? stackalloc IntPtr[keysLength]
+                    : keysListArray.AsSpan(0, keysLength);
+                Span<UIntPtr> keysListSizes = keysLength < 256 
+                    ? stackalloc UIntPtr[keysLength] 
+                    : keysListSizesArray.AsSpan(0, keysLength);
+                using var keyHandles = CopyVector(keys, keysList, keysListSizes);
+
+                (valuesListArray, valuesListSizesArray) = values.Length < 256 
+                    ? (null, null)
+                    : (intPtrPool.Rent(values.Length), uintPtrPool.Rent(values.Length));
+                Span<IntPtr> valuesList = values.Length < 256
+                    ? stackalloc IntPtr[values.Length]
+                    : valuesListArray.AsSpan(0, values.Length);
+                Span<UIntPtr> valuesListSizes = values.Length < 256
+                    ? stackalloc UIntPtr[values.Length] 
+                    : valuesListSizesArray.AsSpan(0, values.Length);
+                using var valuesDisposable = CopyVector(values, valuesList, valuesListSizes);
+
+                fixed (void* keysListPtr = keysList,
+                    keysListSizesPtr = keysListSizes,
+                    valuesListPtr = valuesList,
+                    valuesListSizesPtr = valuesListSizes)
+                {
+                    if (columnFamily is null)
+                    {
+                        Putv(
+                            keys.Length, (IntPtr)keysListPtr, (IntPtr)keysListSizesPtr,
+                            values.Length, (IntPtr)valuesListPtr, (IntPtr)valuesListSizesPtr);
+                    }
+                    else
+                    {
+                        PutvCf(columnFamily.Handle,
+                            keys.Length, (IntPtr)keysListPtr, (IntPtr)keysListSizesPtr,
+                            values.Length, (IntPtr)valuesListPtr, (IntPtr)valuesListSizesPtr);
+                    }
+                }
+                return this; 
+            }
+            finally
+            {
+                if (keysListArray is not null) intPtrPool.Return(keysListArray);
+                if (keysListSizesArray is not null) uintPtrPool.Return(keysListSizesArray);
+                if (valuesListArray is not null) intPtrPool.Return(valuesListArray);
+                if (valuesListSizesArray is not null) uintPtrPool.Return(valuesListSizesArray);
+            }
+        }
+
+        static unsafe IDisposable CopyVector(ReadOnlySpan<ReadOnlyMemory<byte>> items, Span<IntPtr> itemsList, Span<UIntPtr> itemsListSizes)
+        {
+            var disposable = new MemoryHandleManager(items.Length);
+            for (var i = 0; i < items.Length; i++)
+            {
+                var handle = items[i].Pin();
+                disposable.Add(handle);
+                itemsList[i] = (IntPtr)handle.Pointer;
+                itemsListSizes[i] = (UIntPtr)items[i].Length;
+            }
+            return disposable;
+        }
+
+        class MemoryHandleManager : IDisposable
+        {
+            readonly IList<MemoryHandle> handles;
+
+            public MemoryHandleManager(int capacity)
+            {
+                 handles = new List<MemoryHandle>(capacity);
+            }
+
+            public void Add(MemoryHandle handle) => handles.Add(handle);
+
+            public void Dispose()
+            {
+                for (int i = 0; i < handles.Count; i++)
+                {
+                    handles[i].Dispose();
+                }
+            }
         }
 
         public WriteBatch Putv(int numKeys, IntPtr keysList, IntPtr keysListSizes, int numValues, IntPtr valuesList, IntPtr valuesListSizes)


### PR DESCRIPTION
This PR adds `WriteBatch.PutVector` methods as a developer-friendly wrapper of the existing `Putv`/`PutvCf`. fixes #22

There are also overloads that take a single key and a `params` array of values. Obviously, you can't have multiple params arrays in a method, it seemed to me that it was more likely to have a value vector than a key vector. Also, I provided overloads with and without ColumnFamilyHandle parameter since you can't have default value parameters after a `params` parameter.

As per comment on #22, the code only uses stackalloc for list/istSizes when the vector is less than 256 items. For vectors 256 items or longer, the code uses a rented array. The code is a little more complex than I would have wanted due to C# limitations on `Span<T>` and `stackkalloc`. 

There aren't any tests in this project. I've tested similar code in my own library that uses rocksdb-sharp, but it doesn't have vectors larger than 256 so that code remains untested. 

BTW, would it make more sense to add helper methods like this as extension methods? Given the nature of this library as a native code wrapper, there's little difference between extension and "normal" methods, so maybe it's not worth it.
