### PR TITLE
fix: Moving SetInfoLogLevel from ColumnFamilyOptions to DbOptions.

### DIFF
--- a/csharp/src/ColumnFamilyOptions.cs
+++ b/csharp/src/ColumnFamilyOptions.cs
@@ -428,12 +428,6 @@ namespace RocksDbSharp
             return this;
         }
 
-        public ColumnFamilyOptions SetInfoLogLevel(int value)
-        {
-            Native.Instance.rocksdb_options_set_info_log_level(Handle, value);
-            return this;
-        }
-
         /// <summary>
         /// Amount of data to build up in memory (backed by an unsorted log
         /// on disk) before converting to a sorted on-disk file.

--- a/csharp/src/DbOptions.cs
+++ b/csharp/src/DbOptions.cs
@@ -14,6 +14,16 @@ namespace RocksDbSharp
         WillNeed,
     }
 
+    public enum InfoLogLevel
+    {
+        Debug,
+        Info,
+        Warn,
+        Error,
+        Fatal,
+        Header
+    }
+
     // Summaries taken from:
     // rocksdb/include/rocksdb/options.h
     public class DbOptions : ColumnFamilyOptions
@@ -98,6 +108,16 @@ namespace RocksDbSharp
         public DbOptions SetInfoLog(IntPtr logger)
         {
             Native.Instance.rocksdb_options_set_info_log(Handle, logger);
+            return this;
+        }
+
+        /// <summary>
+        /// Specify the info log level.
+        /// Default: Info (for release builds)
+        /// </summary>
+        public DbOptions SetInfoLogLevel(InfoLogLevel value)
+        {
+            Native.Instance.rocksdb_options_set_info_log_level(Handle, (int)value);
             return this;
         }
 


### PR DESCRIPTION
Closes #27

Moved SetLogLevel into the correct class (from ColumnFamilyOptions to DbOptions) and added an enum for better readability. 