### PR TITLE
Deprioritize loading installed version of rocksdb native library

### DIFF
--- a/csharp/src/AutoNativeImport.cs
+++ b/csharp/src/AutoNativeImport.cs
@@ -459,8 +459,8 @@ namespace NativeImport
 
             var baseSearchPaths = basePaths.Where(p => p is object)
                                            .SelectMany(basePath =>
-                                               paths.SelectMany(path => names.Select(n => Path.Combine(basePath, path, importer.Translate(n))))
-                                                    .Concat(names.Select(n => importer.Translate(n))));
+                                               paths.SelectMany(path => names.Select(n => Path.Combine(basePath, path, importer.Translate(n)))))
+                                                    .Concat(names.Select(n => importer.Translate(n)));
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {


### PR DESCRIPTION
According to the current logic the native library is searched at the following locations, paths without directory are looked twice:

```
/root/fix/src/Solution/Project/runtimes/linux-x64/native/librocksdb-8.3.2.so
/root/fix/src/Solution/Project/runtimes/linux-x64/native/librocksdb-8.3.so
/root/fix/src/Solution/Project/runtimes/linux-x64/native/librocksdb-8.so
/root/fix/src/Solution/Project/runtimes/linux-x64/native/librocksdb.so
/root/fix/src/Solution/Project/native/amd64/librocksdb-8.3.2.so
/root/fix/src/Solution/Project/native/amd64/librocksdb-8.3.so
/root/fix/src/Solution/Project/native/amd64/librocksdb-8.so
/root/fix/src/Solution/Project/native/amd64/librocksdb.so
/root/fix/src/Solution/Project/native/librocksdb-8.3.2.so
/root/fix/src/Solution/Project/native/librocksdb-8.3.so
/root/fix/src/Solution/Project/native/librocksdb-8.so
/root/fix/src/Solution/Project/native/librocksdb.so
/root/fix/src/Solution/Project/amd64/librocksdb-8.3.2.so
/root/fix/src/Solution/Project/amd64/librocksdb-8.3.so
/root/fix/src/Solution/Project/amd64/librocksdb-8.so
/root/fix/src/Solution/Project/amd64/librocksdb.so
/root/fix/src/Solution/Project/librocksdb-8.3.2.so
/root/fix/src/Solution/Project/librocksdb-8.3.so
/root/fix/src/Solution/Project/librocksdb-8.so
/root/fix/src/Solution/Project/librocksdb.so
librocksdb-8.3.2.so
librocksdb-8.3.so
librocksdb-8.so
librocksdb.so
/root/fix/src/Solution/artifacts/bin/Project/debug/runtimes/linux-x64/native/librocksdb-8.3.2.so
/root/fix/src/Solution/artifacts/bin/Project/debug/runtimes/linux-x64/native/librocksdb-8.3.so
/root/fix/src/Solution/artifacts/bin/Project/debug/runtimes/linux-x64/native/librocksdb-8.so
/root/fix/src/Solution/artifacts/bin/Project/debug/runtimes/linux-x64/native/librocksdb.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/amd64/librocksdb-8.3.2.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/amd64/librocksdb-8.3.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/amd64/librocksdb-8.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/amd64/librocksdb.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/librocksdb-8.3.2.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/librocksdb-8.3.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/librocksdb-8.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/librocksdb.so
/root/fix/src/Solution/artifacts/bin/Project/debug/amd64/librocksdb-8.3.2.so
/root/fix/src/Solution/artifacts/bin/Project/debug/amd64/librocksdb-8.3.so
/root/fix/src/Solution/artifacts/bin/Project/debug/amd64/librocksdb-8.so
/root/fix/src/Solution/artifacts/bin/Project/debug/amd64/librocksdb.so
/root/fix/src/Solution/artifacts/bin/Project/debug/librocksdb-8.3.2.so
/root/fix/src/Solution/artifacts/bin/Project/debug/librocksdb-8.3.so
/root/fix/src/Solution/artifacts/bin/Project/debug/librocksdb-8.so
/root/fix/src/Solution/artifacts/bin/Project/debug/librocksdb.so
librocksdb-8.3.2.so
librocksdb-8.3.so
librocksdb-8.so
librocksdb.so
```

after the fix it will search firstly in all paths provided by the wrapper before checking PATH:

```
/root/fix/src/Solution/Project/runtimes/linux-x64/native/librocksdb-8.3.2.so
/root/fix/src/Solution/Project/runtimes/linux-x64/native/librocksdb-8.3.so
/root/fix/src/Solution/Project/runtimes/linux-x64/native/librocksdb-8.so
/root/fix/src/Solution/Project/runtimes/linux-x64/native/librocksdb.so
/root/fix/src/Solution/Project/native/amd64/librocksdb-8.3.2.so
/root/fix/src/Solution/Project/native/amd64/librocksdb-8.3.so
/root/fix/src/Solution/Project/native/amd64/librocksdb-8.so
/root/fix/src/Solution/Project/native/amd64/librocksdb.so
/root/fix/src/Solution/Project/native/librocksdb-8.3.2.so
/root/fix/src/Solution/Project/native/librocksdb-8.3.so
/root/fix/src/Solution/Project/native/librocksdb-8.so
/root/fix/src/Solution/Project/native/librocksdb.so
/root/fix/src/Solution/Project/amd64/librocksdb-8.3.2.so
/root/fix/src/Solution/Project/amd64/librocksdb-8.3.so
/root/fix/src/Solution/Project/amd64/librocksdb-8.so
/root/fix/src/Solution/Project/amd64/librocksdb.so
/root/fix/src/Solution/Project/librocksdb-8.3.2.so
/root/fix/src/Solution/Project/librocksdb-8.3.so
/root/fix/src/Solution/Project/librocksdb-8.so
/root/fix/src/Solution/Project/librocksdb.so
/root/fix/src/Solution/artifacts/bin/Project/debug/runtimes/linux-x64/native/librocksdb-8.3.2.so
/root/fix/src/Solution/artifacts/bin/Project/debug/runtimes/linux-x64/native/librocksdb-8.3.so
/root/fix/src/Solution/artifacts/bin/Project/debug/runtimes/linux-x64/native/librocksdb-8.so
/root/fix/src/Solution/artifacts/bin/Project/debug/runtimes/linux-x64/native/librocksdb.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/amd64/librocksdb-8.3.2.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/amd64/librocksdb-8.3.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/amd64/librocksdb-8.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/amd64/librocksdb.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/librocksdb-8.3.2.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/librocksdb-8.3.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/librocksdb-8.so
/root/fix/src/Solution/artifacts/bin/Project/debug/native/librocksdb.so
/root/fix/src/Solution/artifacts/bin/Project/debug/amd64/librocksdb-8.3.2.so
/root/fix/src/Solution/artifacts/bin/Project/debug/amd64/librocksdb-8.3.so
/root/fix/src/Solution/artifacts/bin/Project/debug/amd64/librocksdb-8.so
/root/fix/src/Solution/artifacts/bin/Project/debug/amd64/librocksdb.so
/root/fix/src/Solution/artifacts/bin/Project/debug/librocksdb-8.3.2.so
/root/fix/src/Solution/artifacts/bin/Project/debug/librocksdb-8.3.so
/root/fix/src/Solution/artifacts/bin/Project/debug/librocksdb-8.so
/root/fix/src/Solution/artifacts/bin/Project/debug/librocksdb.so
librocksdb-8.3.2.so
librocksdb-8.3.so
librocksdb-8.so
librocksdb.so
```