### PR TITLE
Add Raft-based clustering database on top of existing replication

### DIFF
--- a/RocksDbSharp.slnx
+++ b/RocksDbSharp.slnx
@@ -7,6 +7,7 @@
     <File Path="build-native/build-rocksdb.sh" />
   </Folder>
   <Folder Name="/Tests/">
+    <Project Path="Tests/ClusterTest/ClusterTest.csproj" />
     <Project Path="Tests/ConsoleTest/ConsoleTest.csproj" />
     <Project Path="Tests/MergeTest/MergeTests.csproj" />
     <Project Path="Tests/ReplicationTest/ReplicationTest.csproj" />

--- a/Tests/ClusterTest/ClusterNodeHost.cs
+++ b/Tests/ClusterTest/ClusterNodeHost.cs
@@ -353,7 +353,7 @@ public sealed class ClusterNodeHost : IAsyncDisposable
             foreach (var h in sourceHashes)
             {
                 if (!h.Found) continue;
-                var localHash = ReplicationDelta.ComputeFileHash(Path.Combine(_cfg.DbPath, h.Name));
+                var localHash = ReplicationDelta.ComputeFileSignature(Path.Combine(_cfg.DbPath, h.Name));
                 if (string.Equals(localHash, h.Hash, StringComparison.OrdinalIgnoreCase))
                     verified.Add(new FileInventoryItem { Name = h.Name, Size = sizeByName[h.Name] });
             }

--- a/Tests/ClusterTest/ClusterNodeHost.cs
+++ b/Tests/ClusterTest/ClusterNodeHost.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Net.Client;
+using MagicOnion.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using RocksDbSharp;
+
+namespace ClusterTest;
+
+/// <summary>
+/// Per-process host. Owns the RocksDB instance, the RaftClusterNode, the
+/// MagicOnion server, and (when this node is a follower) the WAL-streaming
+/// background task that ingests batches from the current leader.
+/// </summary>
+public sealed class ClusterNodeHost : IAsyncDisposable
+{
+    public RocksDb Db { get; private set; } = null!;
+    public RaftClusterNode Node { get; private set; } = null!;
+
+    private readonly NodeConfiguration _cfg;
+    private readonly ClusterPeerTransport _transport = new();
+    private readonly CancellationTokenSource _cts = new();
+
+    private WebApplication? _app;
+    private Task? _appRunTask;
+    private Task? _followerStreamTask;
+    private string? _currentFollowingLeader;
+    private CancellationTokenSource? _followerCts;
+    private RaftPersistentState? _state;
+
+    public ClusterNodeHost(NodeConfiguration cfg)
+    {
+        _cfg = cfg;
+    }
+
+    public async Task StartAsync()
+    {
+        Directory.CreateDirectory(_cfg.DbPath);
+        var walDir = Path.Combine(_cfg.DbPath, "journal");
+        var raftDir = Path.Combine(_cfg.DbPath, "raft");
+        Directory.CreateDirectory(raftDir);
+
+        _state = new RaftPersistentState(raftDir);
+
+        // Non-bootstrap nodes: pull initial snapshot from primary if their DB is fresh.
+        if (!_cfg.BootstrapPrimary && !Directory.Exists(Path.Combine(_cfg.DbPath, "CURRENT")))
+        {
+            await SyncInitialFromPrimaryAsync();
+        }
+
+        var options = new DbOptions()
+            .SetCreateIfMissing(true)
+            .SetWalDir(walDir)
+            .SetWalTtlSeconds(120)
+            .SetMaxTotalWalSize(1024UL * 1024 * 32)
+            .SetWalSizeLimitMB(1024UL * 1024 * 4);
+        Db = RocksDb.Open(options, _cfg.DbPath);
+        Db.DisableFileDeletions();
+
+        var peers = _cfg.AllMembers.Where(m => m.NodeId != _cfg.NodeId)
+                                   .Select(m => new ClusterMember(m.NodeId, m.Endpoint))
+                                   .ToList();
+
+        var raftCfg = new RaftConfig(
+            nodeId: _cfg.NodeId,
+            endpoint: _cfg.Endpoint,
+            peers: peers,
+            bootstrapPrimary: _cfg.BootstrapPrimary,
+            electionTimeoutMinMs: _cfg.ElectionTimeoutMinMs,
+            electionTimeoutMaxMs: _cfg.ElectionTimeoutMaxMs,
+            heartbeatIntervalMs: _cfg.HeartbeatIntervalMs,
+            bootstrapInSyncLagThreshold: _cfg.BootstrapInSyncLagThreshold);
+
+        Node = new RaftClusterNode(raftCfg, _state, Db, _transport);
+
+        Node.LeaderChanged += OnLeaderChanged;
+        Node.RoleChanged += (s, e) =>
+            Log($"role -> {e.Role} (term {e.Term})");
+        Node.ModeChanged += (s, e) =>
+            Log($"mode -> {e.Mode}");
+
+        await StartServerAsync();
+
+        Node.Start();
+
+        // If we are a non-bootstrap follower, start streaming from the bootstrap primary immediately.
+        if (!_cfg.BootstrapPrimary)
+        {
+            var primary = _cfg.AllMembers.FirstOrDefault(m => m.IsBootstrapPrimary);
+            if (primary != null && primary.NodeId != _cfg.NodeId)
+            {
+                EnsureFollowerStream(primary.NodeId, primary.Endpoint);
+            }
+        }
+    }
+
+    private void OnLeaderChanged(object? sender, LeaderChangedEventArgs e)
+    {
+        Log($"leader -> {e.LeaderId ?? "(none)"} term {e.Term}");
+        if (e.LeaderId == null || e.LeaderId == _cfg.NodeId)
+        {
+            CancelFollowerStream();
+            return;
+        }
+        var leader = _cfg.AllMembers.FirstOrDefault(m => m.NodeId == e.LeaderId);
+        if (leader != null) EnsureFollowerStream(leader.NodeId, leader.Endpoint);
+    }
+
+    private void CancelFollowerStream()
+    {
+        var c = _followerCts;
+        _followerCts = null;
+        _currentFollowingLeader = null;
+        try { c?.Cancel(); } catch { }
+    }
+
+    private void EnsureFollowerStream(string leaderId, string leaderEndpoint)
+    {
+        if (_currentFollowingLeader == leaderId && _followerStreamTask is { IsCompleted: false }) return;
+        CancelFollowerStream();
+        _followerCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+        _currentFollowingLeader = leaderId;
+        var ct = _followerCts.Token;
+        _followerStreamTask = Task.Run(() => RunFollowerStreamAsync(leaderId, leaderEndpoint, ct));
+    }
+
+    private async Task RunFollowerStreamAsync(string leaderId, string endpoint, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var ch = GrpcChannel.ForAddress(endpoint);
+                var client = MagicOnionClient.Create<IClusterService>(ch);
+                ulong startSeq = Db.GetLatestSequenceNumber() + 1;
+                Log($"following {leaderId} from seq {startSeq:n0}");
+                var stream = await client.SyncUpdatesAsync(new SyncUpdatesRequest
+                {
+                    NodeId = _cfg.NodeId,
+                    StartSeq = startSeq,
+                });
+
+                var consumer = new ReplicationConsumer(Db);
+                int n = 0;
+                while (await stream.ResponseStream.MoveNext(ct))
+                {
+                    var batch = stream.ResponseStream.Current;
+                    Node.HandleObservedLeader(batch.LeaderId, batch.LeaderTerm);
+                    // record term -> seq range as we observe new terms
+                    var lastTerm = _state!.Terms.GetLast();
+                    if (batch.LeaderTerm != lastTerm.Term)
+                        _state.RecordTermRange(batch.SequenceNumber, batch.LeaderTerm);
+                    consumer.IngestBatch(batch.SequenceNumber, batch.Data);
+                    batch.ReturnToPool();
+                    n++;
+                    if (n % 500 == 0)
+                    {
+                        await client.ReportLastSyncSequenceNumber(_cfg.NodeId, Db.GetLatestSequenceNumber());
+                    }
+                }
+            }
+            catch (OperationCanceledException) { break; }
+            catch (Exception ex)
+            {
+                Log($"follower stream error: {ex.Message}; retrying in 1s");
+                try { await Task.Delay(1000, ct); } catch { }
+            }
+        }
+    }
+
+    private async Task SyncInitialFromPrimaryAsync()
+    {
+        var primary = _cfg.AllMembers.FirstOrDefault(m => m.IsBootstrapPrimary);
+        if (primary == null) throw new InvalidOperationException("No bootstrap primary in configuration");
+        if (primary.NodeId == _cfg.NodeId) return;
+
+        Log($"snapshot sync from {primary.NodeId} @ {primary.Endpoint}");
+
+        // primary may not be up yet; retry
+        Exception? last = null;
+        for (int attempt = 0; attempt < 30; attempt++)
+        {
+            try
+            {
+                var ch = GrpcChannel.ForAddress(primary.Endpoint);
+                var client = MagicOnionClient.Create<IClusterService>(ch);
+                var stream = await client.SyncInitialStateAsync();
+                Directory.CreateDirectory(_cfg.DbPath);
+                while (await stream.ResponseStream.MoveNext(CancellationToken.None))
+                {
+                    var file = stream.ResponseStream.Current;
+                    var dest = Path.Combine(_cfg.DbPath, file.FileName);
+                    await File.WriteAllBytesAsync(dest, file.Content);
+                }
+                Log("snapshot sync complete");
+                return;
+            }
+            catch (Exception ex)
+            {
+                last = ex;
+                await Task.Delay(1000);
+            }
+        }
+        throw new Exception("snapshot sync failed", last);
+    }
+
+    private async Task StartServerAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddGrpc();
+        builder.Services.AddMagicOnion();
+        builder.Services.AddSingleton(this);
+        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+        builder.WebHost.ConfigureKestrel(o =>
+        {
+            o.ListenLocalhost(_cfg.Port, lo => lo.Protocols = HttpProtocols.Http2);
+        });
+        _app = builder.Build();
+        _app.MapMagicOnionService();
+        _appRunTask = _app.RunAsync(_cts.Token);
+        await Task.Delay(300); // let the listener bind
+    }
+
+    public List<ClusterMemberInfo> GetMemberInfos() =>
+        _cfg.AllMembers.Select(m => new ClusterMemberInfo { NodeId = m.NodeId, Endpoint = m.Endpoint }).ToList();
+
+    public void OnFollowerProgress(string nodeId, ulong seq)
+    {
+        // hook for the host - kept for symmetry with the existing replication module
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        try { if (_app != null) await _app.StopAsync(); } catch { }
+        try { if (_appRunTask != null) await _appRunTask; } catch { }
+        _transport.Dispose();
+        Node?.Dispose();
+        Db?.Dispose();
+    }
+
+    private void Log(string msg) =>
+        Console.WriteLine($"[{DateTimeOffset.UtcNow:HH:mm:ss.fff} {_cfg.NodeId}] {msg}");
+}
+
+public sealed class NodeConfiguration
+{
+    public string NodeId { get; set; } = "";
+    public string Endpoint { get; set; } = "";
+    public int Port { get; set; }
+    public string DbPath { get; set; } = "";
+    public bool BootstrapPrimary { get; set; }
+    public List<MemberConfig> AllMembers { get; set; } = new();
+    public int ElectionTimeoutMinMs { get; set; } = 1500;
+    public int ElectionTimeoutMaxMs { get; set; } = 3000;
+    public int HeartbeatIntervalMs { get; set; } = 300;
+    public ulong BootstrapInSyncLagThreshold { get; set; } = 1000;
+}
+
+public sealed class MemberConfig
+{
+    public string NodeId { get; set; } = "";
+    public string Endpoint { get; set; } = "";
+    public bool IsBootstrapPrimary { get; set; }
+}

--- a/Tests/ClusterTest/ClusterNodeHost.cs
+++ b/Tests/ClusterTest/ClusterNodeHost.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -26,9 +27,17 @@ public sealed class ClusterNodeHost : IAsyncDisposable
     public RocksDb Db { get; private set; } = null!;
     public RaftClusterNode Node { get; private set; } = null!;
 
+    public bool IsResyncing => _resyncing;
+    public bool WriteLoadEnabled
+    {
+        get => _writeLoadEnabled;
+        set => _writeLoadEnabled = value;
+    }
+
     private readonly NodeConfiguration _cfg;
     private readonly ClusterPeerTransport _transport = new();
     private readonly CancellationTokenSource _cts = new();
+    private readonly SemaphoreSlim _resyncGate = new(1, 1);
 
     private WebApplication? _app;
     private Task? _appRunTask;
@@ -36,6 +45,8 @@ public sealed class ClusterNodeHost : IAsyncDisposable
     private string? _currentFollowingLeader;
     private CancellationTokenSource? _followerCts;
     private RaftPersistentState? _state;
+    private volatile bool _resyncing;
+    private volatile bool _writeLoadEnabled = true;
 
     public ClusterNodeHost(NodeConfiguration cfg)
     {
@@ -45,26 +56,20 @@ public sealed class ClusterNodeHost : IAsyncDisposable
     public async Task StartAsync()
     {
         Directory.CreateDirectory(_cfg.DbPath);
-        var walDir = Path.Combine(_cfg.DbPath, "journal");
         var raftDir = Path.Combine(_cfg.DbPath, "raft");
         Directory.CreateDirectory(raftDir);
 
         _state = new RaftPersistentState(raftDir);
 
-        // Non-bootstrap nodes: pull initial snapshot from primary if their DB is fresh.
-        if (!_cfg.BootstrapPrimary && !Directory.Exists(Path.Combine(_cfg.DbPath, "CURRENT")))
+        // Non-bootstrap nodes: pull initial snapshot from primary only when the
+        // DB is fresh. CURRENT is a *file*; testing it with Directory.Exists
+        // made every restart wrongly re-pull a full snapshot over live data.
+        if (!_cfg.BootstrapPrimary && !File.Exists(Path.Combine(_cfg.DbPath, "CURRENT")))
         {
             await SyncInitialFromPrimaryAsync();
         }
 
-        var options = new DbOptions()
-            .SetCreateIfMissing(true)
-            .SetWalDir(walDir)
-            .SetWalTtlSeconds(120)
-            .SetMaxTotalWalSize(1024UL * 1024 * 32)
-            .SetWalSizeLimitMB(1024UL * 1024 * 4);
-        Db = RocksDb.Open(options, _cfg.DbPath);
-        Db.DisableFileDeletions();
+        OpenDatabase();
 
         var peers = _cfg.AllMembers.Where(m => m.NodeId != _cfg.NodeId)
                                    .Select(m => new ClusterMember(m.NodeId, m.Endpoint))
@@ -87,6 +92,7 @@ public sealed class ClusterNodeHost : IAsyncDisposable
             Log($"role -> {e.Role} (term {e.Term})");
         Node.ModeChanged += (s, e) =>
             Log($"mode -> {e.Mode}");
+        Node.ResyncRequired += (s, e) => TriggerResync();
 
         await StartServerAsync();
 
@@ -102,6 +108,61 @@ public sealed class ClusterNodeHost : IAsyncDisposable
             }
         }
     }
+
+    private void OpenDatabase()
+    {
+        var walDir = Path.Combine(_cfg.DbPath, "journal");
+        var options = new DbOptions()
+            .SetCreateIfMissing(true)
+            .SetWalDir(walDir)
+            .SetWalTtlSeconds(120)
+            .SetMaxTotalWalSize(1024UL * 1024 * 32)
+            .SetWalSizeLimitMB(1024UL * 1024 * 4);
+        Db = RocksDb.Open(options, _cfg.DbPath);
+        Db.DisableFileDeletions();
+    }
+
+    // -----------------------------------------------------------------------
+    // Write helpers (leader-side)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Fire-and-forget write used by the load generator. Returns false when
+    /// this node is not the leader (or is rebuilding itself) so the generator
+    /// stops immediately after a step-down instead of polluting the local WAL.
+    /// </summary>
+    public bool TryWriteAsLeader(string key, string value)
+    {
+        if (_resyncing) return false;
+        if (Node is not { Role: RaftRole.Leader }) return false;
+        Db.Put(key, value);
+        return true;
+    }
+
+    /// <summary>
+    /// Write acknowledged only after the entry is committed (replicated to a
+    /// quorum). This is the durability contract Raft offers to clients.
+    /// </summary>
+    public async Task<bool> WriteCommittedAsync(string key, string value, TimeSpan timeout)
+    {
+        if (_resyncing || Node.Role != RaftRole.Leader) return false;
+        Db.Put(key, value);
+        ulong seq = Db.GetLatestSequenceNumber();
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            if (Node.CommitSeq >= seq) return true;
+            if (Node.Role != RaftRole.Leader) return false;
+            await Task.Delay(15);
+        }
+        return false;
+    }
+
+    public string SerializeTerms() => _state!.Terms.Serialize();
+
+    // -----------------------------------------------------------------------
+    // Follower stream
+    // -----------------------------------------------------------------------
 
     private void OnLeaderChanged(object? sender, LeaderChangedEventArgs e)
     {
@@ -125,6 +186,7 @@ public sealed class ClusterNodeHost : IAsyncDisposable
 
     private void EnsureFollowerStream(string leaderId, string leaderEndpoint)
     {
+        if (_resyncing) return; // the resync flow re-attaches when it finishes
         if (_currentFollowingLeader == leaderId && _followerStreamTask is { IsCompleted: false }) return;
         CancelFollowerStream();
         _followerCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
@@ -137,11 +199,38 @@ public sealed class ClusterNodeHost : IAsyncDisposable
     {
         while (!ct.IsCancellationRequested)
         {
+            GrpcChannel? ch = null;
+            CancellationTokenSource? connCts = null;
             try
             {
-                var ch = GrpcChannel.ForAddress(endpoint);
+                ch = GrpcChannel.ForAddress(endpoint);
                 var client = MagicOnionClient.Create<IClusterService>(ch);
-                ulong startSeq = Db.GetLatestSequenceNumber() + 1;
+
+                // Raft's AppendEntries consistency check, done once at attach
+                // time: the leader confirms that our (latestSeq, term) tail
+                // exists identically in its log. A diverged tail (uncommitted
+                // writes from a deposed leadership) cannot be truncated out of
+                // a RocksDB WAL, so the whole replica is rebuilt instead.
+                ulong myLatest = Db.GetLatestSequenceNumber();
+                var check = await client.CheckLogConsistencyAsync(new LogConsistencyRequest
+                {
+                    NodeId = _cfg.NodeId,
+                    FollowerLatestSeq = myLatest,
+                    FollowerTermAtLatest = Node.GetTermForSeq(myLatest),
+                });
+                if (!check.IsLeader)
+                {
+                    await Task.Delay(500, ct);
+                    continue;
+                }
+                if (!check.Consistent)
+                {
+                    Log($"log diverged from leader {leaderId}; scheduling full resync");
+                    TriggerResync();
+                    return;
+                }
+
+                ulong startSeq = myLatest + 1;
                 Log($"following {leaderId} from seq {startSeq:n0}");
                 var stream = await client.SyncUpdatesAsync(new SyncUpdatesRequest
                 {
@@ -149,23 +238,53 @@ public sealed class ClusterNodeHost : IAsyncDisposable
                     StartSeq = startSeq,
                 });
 
+                connCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                var reporterCt = connCts.Token;
+                // Report progress on a timer rather than every N batches so the
+                // leader's matchSeq (and therefore the commit index) keeps
+                // advancing even when the write load pauses.
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        using var rch = GrpcChannel.ForAddress(endpoint);
+                        var rclient = MagicOnionClient.Create<IClusterService>(rch);
+                        while (!reporterCt.IsCancellationRequested)
+                        {
+                            if (!_resyncing)
+                            {
+                                try { await rclient.ReportLastSyncSequenceNumber(_cfg.NodeId, Db.GetLatestSequenceNumber()); }
+                                catch { }
+                            }
+                            await Task.Delay(200, reporterCt);
+                        }
+                    }
+                    catch (OperationCanceledException) { }
+                }, reporterCt);
+
                 var consumer = new ReplicationConsumer(Db);
-                int n = 0;
                 while (await stream.ResponseStream.MoveNext(ct))
                 {
                     var batch = stream.ResponseStream.Current;
+
+                    // A faithful replica ingests the leader's batches at
+                    // exactly the same sequence numbers. Any gap means the
+                    // leader truncated WAL past our position; any overlap
+                    // means a local write slipped in. Both diverge the copy.
+                    ulong expected = Db.GetLatestSequenceNumber() + 1;
+                    if (batch.SequenceNumber != expected)
+                    {
+                        Log($"WAL stream mismatch: expected seq {expected:n0}, got {batch.SequenceNumber:n0}; scheduling full resync");
+                        batch.ReturnToPool();
+                        TriggerResync();
+                        return;
+                    }
+
                     Node.HandleObservedLeader(batch.LeaderId, batch.LeaderTerm);
-                    // record term -> seq range as we observe new terms
-                    var lastTerm = _state!.Terms.GetLast();
-                    if (batch.LeaderTerm != lastTerm.Term)
-                        _state.RecordTermRange(batch.SequenceNumber, batch.LeaderTerm);
+                    if (batch.EntryTerm > 0)
+                        _state!.RecordTermRange(batch.SequenceNumber, batch.EntryTerm);
                     consumer.IngestBatch(batch.SequenceNumber, batch.Data);
                     batch.ReturnToPool();
-                    n++;
-                    if (n % 500 == 0)
-                    {
-                        await client.ReportLastSyncSequenceNumber(_cfg.NodeId, Db.GetLatestSequenceNumber());
-                    }
                 }
             }
             catch (OperationCanceledException) { break; }
@@ -174,8 +293,18 @@ public sealed class ClusterNodeHost : IAsyncDisposable
                 Log($"follower stream error: {ex.Message}; retrying in 1s");
                 try { await Task.Delay(1000, ct); } catch { }
             }
+            finally
+            {
+                connCts?.Cancel();
+                connCts?.Dispose();
+                ch?.Dispose();
+            }
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Snapshot pull + full resync
+    // -----------------------------------------------------------------------
 
     private async Task SyncInitialFromPrimaryAsync()
     {
@@ -191,17 +320,7 @@ public sealed class ClusterNodeHost : IAsyncDisposable
         {
             try
             {
-                var ch = GrpcChannel.ForAddress(primary.Endpoint);
-                var client = MagicOnionClient.Create<IClusterService>(ch);
-                var stream = await client.SyncInitialStateAsync();
-                Directory.CreateDirectory(_cfg.DbPath);
-                while (await stream.ResponseStream.MoveNext(CancellationToken.None))
-                {
-                    var file = stream.ResponseStream.Current;
-                    var dest = Path.Combine(_cfg.DbPath, file.FileName);
-                    await File.WriteAllBytesAsync(dest, file.Content);
-                }
-                Log("snapshot sync complete");
+                await PullSnapshotAsync(primary.Endpoint);
                 return;
             }
             catch (Exception ex)
@@ -212,6 +331,134 @@ public sealed class ClusterNodeHost : IAsyncDisposable
         }
         throw new Exception("snapshot sync failed", last);
     }
+
+    private async Task PullSnapshotAsync(string endpoint)
+    {
+        using var ch = GrpcChannel.ForAddress(endpoint);
+        var client = MagicOnionClient.Create<IClusterService>(ch);
+        var stream = await client.SyncInitialStateAsync();
+        Directory.CreateDirectory(_cfg.DbPath);
+
+        FileStream? current = null;
+        string? currentName = null;
+        try
+        {
+            while (await stream.ResponseStream.MoveNext(_cts.Token))
+            {
+                var chunk = stream.ResponseStream.Current;
+                if (currentName != chunk.FileName)
+                {
+                    current?.Dispose();
+                    currentName = chunk.FileName;
+                    current = new FileStream(Path.Combine(_cfg.DbPath, chunk.FileName), FileMode.Create, FileAccess.Write);
+                }
+                if (chunk.Content.Length > 0)
+                    await current!.WriteAsync(chunk.Content);
+            }
+        }
+        finally
+        {
+            current?.Dispose();
+        }
+
+        // The restored log is byte-for-byte the leader's log, so the leader's
+        // term map is the correct description of it.
+        var terms = await client.GetRaftTermsAsync();
+        _state!.ReplaceTerms(RaftLogTerms.Deserialize(terms));
+        Log("snapshot sync complete");
+    }
+
+    public void TriggerResync()
+    {
+        if (_resyncing || _cts.IsCancellationRequested) return;
+        _ = Task.Run(PerformResyncAsync);
+    }
+
+    private async Task PerformResyncAsync()
+    {
+        if (!await _resyncGate.WaitAsync(0)) return;
+        try
+        {
+            if (_cts.IsCancellationRequested) return;
+            _resyncing = true;
+            Node.BeginResync();
+            CancelFollowerStream();
+            Log("resync: local log conflicts with the leader's; rebuilding replica from a leader snapshot");
+
+            // Give in-flight RPC handlers a moment to finish touching the DB
+            // before it is disposed.
+            await Task.Delay(1000);
+            Db.Dispose();
+
+            while (!_cts.IsCancellationRequested)
+            {
+                try
+                {
+                    var leader = await FindLeaderAsync();
+                    if (leader == null)
+                    {
+                        await Task.Delay(1000);
+                        continue;
+                    }
+                    WipeDataDirectory();
+                    await PullSnapshotAsync(leader.Endpoint);
+                    OpenDatabase();
+                    Node.CompleteResync(Db);
+                    _resyncing = false;
+                    Log($"resync complete at seq {Db.GetLatestSequenceNumber():n0}; rejoining {leader.NodeId}");
+                    EnsureFollowerStream(leader.NodeId, leader.Endpoint);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    Log($"resync attempt failed: {ex.Message}; retrying in 1s");
+                    await Task.Delay(1000);
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        finally
+        {
+            _resyncGate.Release();
+        }
+    }
+
+    private async Task<MemberConfig?> FindLeaderAsync()
+    {
+        foreach (var m in _cfg.AllMembers.Where(m => m.NodeId != _cfg.NodeId))
+        {
+            try
+            {
+                using var ch = GrpcChannel.ForAddress(m.Endpoint);
+                var client = MagicOnionClient.Create<IClusterService>(ch);
+                var s = await client.GetStatusAsync();
+                if (s.Role == nameof(RaftRole.Leader)) return m;
+                if (!string.IsNullOrEmpty(s.LeaderId) && s.LeaderId != _cfg.NodeId)
+                {
+                    var l = _cfg.AllMembers.FirstOrDefault(x => x.NodeId == s.LeaderId);
+                    if (l != null) return l;
+                }
+            }
+            catch { }
+        }
+        return null;
+    }
+
+    private void WipeDataDirectory()
+    {
+        foreach (var dir in Directory.GetDirectories(_cfg.DbPath))
+        {
+            if (Path.GetFileName(dir).Equals("raft", StringComparison.OrdinalIgnoreCase)) continue;
+            Directory.Delete(dir, true);
+        }
+        foreach (var file in Directory.GetFiles(_cfg.DbPath))
+        {
+            if (Path.GetFileName(file).Equals("node.json", StringComparison.OrdinalIgnoreCase)) continue;
+            File.Delete(file);
+        }
+    }
+
+    // -----------------------------------------------------------------------
 
     private async Task StartServerAsync()
     {
@@ -245,7 +492,7 @@ public sealed class ClusterNodeHost : IAsyncDisposable
         try { if (_appRunTask != null) await _appRunTask; } catch { }
         _transport.Dispose();
         Node?.Dispose();
-        Db?.Dispose();
+        if (!_resyncing) Db?.Dispose();
     }
 
     private void Log(string msg) =>

--- a/Tests/ClusterTest/ClusterNodeHost.cs
+++ b/Tests/ClusterTest/ClusterNodeHost.cs
@@ -336,9 +336,20 @@ public sealed class ClusterNodeHost : IAsyncDisposable
     {
         using var ch = GrpcChannel.ForAddress(endpoint);
         var client = MagicOnionClient.Create<IClusterService>(ch);
-        var stream = await client.SyncInitialStateAsync();
         Directory.CreateDirectory(_cfg.DbPath);
 
+        // Per-file delta: offer our local immutable files; the leader tells us
+        // which ones to keep and only streams new or changed files, in full.
+        var inventory = ReplicationDelta.ScanImmutableFiles(_cfg.DbPath);
+        var stream = await client.SyncInitialStateAsync(new SnapshotRequest
+        {
+            Files = inventory.Select(f => new FileInventoryItem { Name = f.FileName, Size = f.Size, Hash = f.Hash }).ToList(),
+        });
+
+        bool planApplied = false;
+        int reused = 0;
+        int transferredFiles = 0;
+        long transferredBytes = 0;
         FileStream? current = null;
         string? currentName = null;
         try
@@ -346,14 +357,32 @@ public sealed class ClusterNodeHost : IAsyncDisposable
             while (await stream.ResponseStream.MoveNext(_cts.Token))
             {
                 var chunk = stream.ResponseStream.Current;
+                if (chunk.IsPlan)
+                {
+                    // Delete the journal directory and every local file the
+                    // leader didn't confirm (stale SSTs, MANIFEST, CURRENT)
+                    // before any new file lands; only raft/ (term + vote must
+                    // survive a rebuild) and our config file stay.
+                    ReplicationDelta.PrepareForRestore(_cfg.DbPath, chunk.KeepFiles, new[] { "raft", "node.json" });
+                    reused = chunk.KeepFiles.Count;
+                    planApplied = true;
+                    continue;
+                }
+                if (!planApplied)
+                    throw new InvalidOperationException("snapshot stream did not start with a delta plan");
+
                 if (currentName != chunk.FileName)
                 {
                     current?.Dispose();
                     currentName = chunk.FileName;
                     current = new FileStream(Path.Combine(_cfg.DbPath, chunk.FileName), FileMode.Create, FileAccess.Write);
+                    transferredFiles++;
                 }
                 if (chunk.Content.Length > 0)
+                {
                     await current!.WriteAsync(chunk.Content);
+                    transferredBytes += chunk.Content.Length;
+                }
             }
         }
         finally
@@ -361,11 +390,16 @@ public sealed class ClusterNodeHost : IAsyncDisposable
             current?.Dispose();
         }
 
+        // An empty stream means the source refused (not leader / resyncing);
+        // treating it as success would leave a half-initialized replica.
+        if (!planApplied)
+            throw new InvalidOperationException("snapshot source sent no data (leader unavailable?)");
+
         // The restored log is byte-for-byte the leader's log, so the leader's
         // term map is the correct description of it.
         var terms = await client.GetRaftTermsAsync();
         _state!.ReplaceTerms(RaftLogTerms.Deserialize(terms));
-        Log("snapshot sync complete");
+        Log($"snapshot sync complete: reused {reused} local files, transferred {transferredFiles} files / {transferredBytes:n0} bytes");
     }
 
     public void TriggerResync()
@@ -400,7 +434,9 @@ public sealed class ClusterNodeHost : IAsyncDisposable
                         await Task.Delay(1000);
                         continue;
                     }
-                    WipeDataDirectory();
+                    // PullSnapshotAsync deletes the journal and every file the
+                    // leader doesn't confirm; unchanged SSTs are kept so the
+                    // rebuild only transfers the actual delta.
                     await PullSnapshotAsync(leader.Endpoint);
                     OpenDatabase();
                     Node.CompleteResync(Db);
@@ -442,20 +478,6 @@ public sealed class ClusterNodeHost : IAsyncDisposable
             catch { }
         }
         return null;
-    }
-
-    private void WipeDataDirectory()
-    {
-        foreach (var dir in Directory.GetDirectories(_cfg.DbPath))
-        {
-            if (Path.GetFileName(dir).Equals("raft", StringComparison.OrdinalIgnoreCase)) continue;
-            Directory.Delete(dir, true);
-        }
-        foreach (var file in Directory.GetFiles(_cfg.DbPath))
-        {
-            if (Path.GetFileName(file).Equals("node.json", StringComparison.OrdinalIgnoreCase)) continue;
-            File.Delete(file);
-        }
     }
 
     // -----------------------------------------------------------------------

--- a/Tests/ClusterTest/ClusterNodeHost.cs
+++ b/Tests/ClusterTest/ClusterNodeHost.cs
@@ -27,6 +27,7 @@ public sealed class ClusterNodeHost : IAsyncDisposable
     public RocksDb Db { get; private set; } = null!;
     public RaftClusterNode Node { get; private set; } = null!;
 
+    public string DbPath => _cfg.DbPath;
     public bool IsResyncing => _resyncing;
     public bool WriteLoadEnabled
     {
@@ -338,13 +339,28 @@ public sealed class ClusterNodeHost : IAsyncDisposable
         var client = MagicOnionClient.Create<IClusterService>(ch);
         Directory.CreateDirectory(_cfg.DbPath);
 
-        // Per-file delta: offer our local immutable files; the leader tells us
-        // which ones to keep and only streams new or changed files, in full.
-        var inventory = ReplicationDelta.ScanImmutableFiles(_cfg.DbPath);
-        var stream = await client.SyncInitialStateAsync(new SnapshotRequest
+        // Per-file delta, with lazy hashing: scan local immutable files by
+        // name + size only, ask the source for hashes of the ones it also
+        // holds at that exact name + size, and hash our copies of just those
+        // candidates. Files that cannot match are never hashed on either side.
+        var local = ReplicationDelta.ScanImmutableFiles(_cfg.DbPath);
+        var verified = new List<FileInventoryItem>();
+        if (local.Count > 0)
         {
-            Files = inventory.Select(f => new FileInventoryItem { Name = f.FileName, Size = f.Size, Hash = f.Hash }).ToList(),
-        });
+            var sourceHashes = await client.GetFileHashesAsync(
+                local.Select(f => new FileHashQuery { Name = f.FileName, Size = f.Size }).ToList());
+            var sizeByName = local.ToDictionary(f => f.FileName, f => f.Size);
+            foreach (var h in sourceHashes)
+            {
+                if (!h.Found) continue;
+                var localHash = ReplicationDelta.ComputeFileHash(Path.Combine(_cfg.DbPath, h.Name));
+                if (string.Equals(localHash, h.Hash, StringComparison.OrdinalIgnoreCase))
+                    verified.Add(new FileInventoryItem { Name = h.Name, Size = sizeByName[h.Name] });
+            }
+            Log($"snapshot delta: verified {verified.Count} of {local.Count} local files against the source");
+        }
+
+        var stream = await client.SyncInitialStateAsync(new SnapshotRequest { Files = verified });
 
         bool planApplied = false;
         int reused = 0;

--- a/Tests/ClusterTest/ClusterNodeHost.cs
+++ b/Tests/ClusterTest/ClusterNodeHost.cs
@@ -353,7 +353,7 @@ public sealed class ClusterNodeHost : IAsyncDisposable
             foreach (var h in sourceHashes)
             {
                 if (!h.Found) continue;
-                var localHash = ReplicationDelta.ComputeFileSignature(Path.Combine(_cfg.DbPath, h.Name));
+                var localHash = await ReplicationDelta.ComputeFileSignatureAsync(Path.Combine(_cfg.DbPath, h.Name));
                 if (string.Equals(localHash, h.Hash, StringComparison.OrdinalIgnoreCase))
                     verified.Add(new FileInventoryItem { Name = h.Name, Size = sizeByName[h.Name] });
             }

--- a/Tests/ClusterTest/ClusterPeerTransport.cs
+++ b/Tests/ClusterTest/ClusterPeerTransport.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Net.Client;
+using MagicOnion.Client;
+using RocksDbSharp;
+
+namespace ClusterTest;
+
+/// <summary>
+/// Implements the IPeerTransport contract that RaftClusterNode uses to fan out
+/// RequestVote / Heartbeat RPCs. Maintains one MagicOnion client per peer.
+/// </summary>
+internal sealed class ClusterPeerTransport : IPeerTransport, IDisposable
+{
+    private readonly ConcurrentDictionary<string, (GrpcChannel ch, IClusterService client)> _clients = new();
+
+    private (GrpcChannel ch, IClusterService client) GetClient(ClusterMember peer)
+    {
+        return _clients.GetOrAdd(peer.NodeId, _ =>
+        {
+            var ch = GrpcChannel.ForAddress(peer.Endpoint);
+            var client = MagicOnionClient.Create<IClusterService>(ch);
+            return (ch, client);
+        });
+    }
+
+    public async Task<RequestVoteResult?> SendRequestVoteAsync(
+        ClusterMember peer, long term, string candidateId, ulong lastLogSeq, long lastLogTerm, CancellationToken ct)
+    {
+        try
+        {
+            var (_, client) = GetClient(peer);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(TimeSpan.FromSeconds(2));
+            var resp = await client.RequestVoteAsync(new RequestVoteRequest
+            {
+                Term = term,
+                CandidateId = candidateId,
+                LastLogSeq = lastLogSeq,
+                LastLogTerm = lastLogTerm,
+            });
+            return new RequestVoteResult(resp.Term, resp.VoteGranted);
+        }
+        catch { return null; }
+    }
+
+    public async Task<AppendEntriesResult?> SendHeartbeatAsync(ClusterMember peer, HeartbeatPayload payload, CancellationToken ct)
+    {
+        try
+        {
+            var (_, client) = GetClient(peer);
+            var resp = await client.HeartbeatAsync(new HeartbeatRequest
+            {
+                Term = payload.Term,
+                LeaderId = payload.LeaderId,
+                PrevLogSeq = payload.PrevLogSeq,
+                PrevLogTerm = payload.PrevLogTerm,
+                LeaderCommit = payload.LeaderCommit,
+                LeaderMode = (int)payload.LeaderMode,
+            });
+            return new AppendEntriesResult(resp.Term, resp.Success, resp.LastSeq, resp.Reason);
+        }
+        catch { return null; }
+    }
+
+    public void Dispose()
+    {
+        foreach (var entry in _clients.Values)
+        {
+            try { entry.ch.Dispose(); } catch { }
+        }
+        _clients.Clear();
+    }
+}

--- a/Tests/ClusterTest/ClusterService.cs
+++ b/Tests/ClusterTest/ClusterService.cs
@@ -1,0 +1,156 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using MagicOnion;
+using MagicOnion.Server;
+using RocksDbSharp;
+
+namespace ClusterTest;
+
+public class ClusterService : ServiceBase<IClusterService>, IClusterService
+{
+    private readonly ClusterNodeHost _host;
+
+    public ClusterService(ClusterNodeHost host)
+    {
+        _host = host;
+    }
+
+    public UnaryResult<RequestVoteResponse> RequestVoteAsync(RequestVoteRequest req)
+    {
+        var r = _host.Node.HandleRequestVote(req.Term, req.CandidateId, req.LastLogSeq, req.LastLogTerm);
+        return new UnaryResult<RequestVoteResponse>(new RequestVoteResponse
+        {
+            Term = r.Term,
+            VoteGranted = r.VoteGranted,
+        });
+    }
+
+    public UnaryResult<AppendEntriesResponse> HeartbeatAsync(HeartbeatRequest req)
+    {
+        var r = _host.Node.HandleAppendEntries(
+            req.Term, req.LeaderId, req.PrevLogSeq, req.PrevLogTerm, req.LeaderCommit, (ClusterMode)req.LeaderMode);
+        return new UnaryResult<AppendEntriesResponse>(new AppendEntriesResponse
+        {
+            Term = r.Term,
+            Success = r.Success,
+            LastSeq = r.LastSeq,
+            Reason = r.Reason,
+        });
+    }
+
+    public UnaryResult<JoinResponse> JoinAsync(JoinRequest req)
+    {
+        var resp = new JoinResponse
+        {
+            Accepted = true,
+            LeaderId = _host.Node.CurrentLeaderId ?? "",
+            Term = _host.Node.CurrentTerm,
+            Mode = (int)_host.Node.Mode,
+            Members = _host.GetMemberInfos(),
+        };
+        return new UnaryResult<JoinResponse>(resp);
+    }
+
+    public UnaryResult<NodeStatus> GetStatusAsync()
+    {
+        var s = new NodeStatus
+        {
+            NodeId = _host.Node.NodeId,
+            Role = _host.Node.Role.ToString(),
+            Term = _host.Node.CurrentTerm,
+            LeaderId = _host.Node.CurrentLeaderId,
+            LatestSeq = _host.Db.GetLatestSequenceNumber(),
+            CommitSeq = _host.Node.CommitSeq,
+            Mode = (int)_host.Node.Mode,
+            BootstrapInSyncCount = _host.Node.BootstrapInSyncCount,
+            Peers = _host.Node.Peers.Select(p => new PeerInfo
+            {
+                NodeId = p.Member.NodeId,
+                MatchSeq = p.MatchSeq,
+                Reachable = p.IsReachable,
+            }).ToList(),
+        };
+        return new UnaryResult<NodeStatus>(s);
+    }
+
+    public async Task<ServerStreamingResult<ClusterFileData>> SyncInitialStateAsync()
+    {
+        var stream = GetServerStreamingContext<ClusterFileData>();
+        var src = new ReplicationSource(_host.Db);
+        var tempPath = Path.Combine(Path.GetTempPath(), "rocksdb_cluster_snap_" + Guid.NewGuid().ToString());
+        using (var session = src.GetInitialState(tempPath))
+        {
+            foreach (var file in session.Files)
+            {
+                using var ms = new MemoryStream();
+                await file.FileStream.CopyToAsync(ms);
+                await stream.WriteAsync(new ClusterFileData
+                {
+                    FileName = file.FileName,
+                    FileSize = file.FileSize,
+                    Content = ms.ToArray(),
+                });
+                file.Dispose();
+            }
+        }
+        return stream.Result();
+    }
+
+    public async Task<ServerStreamingResult<ClusterBatchData>> SyncUpdatesAsync(SyncUpdatesRequest req)
+    {
+        var stream = GetServerStreamingContext<ClusterBatchData>();
+        var src = new ReplicationSource(_host.Db);
+
+        ulong currentSeq = req.StartSeq;
+        var ct = Context.CallContext.CancellationToken;
+
+        while (!ct.IsCancellationRequested)
+        {
+            bool any = false;
+            ulong latest = _host.Db.GetLatestSequenceNumber();
+            if (currentSeq <= latest)
+            {
+                foreach (var batch in src.GetPooledWalUpdates(currentSeq))
+                {
+                    any = true;
+                    long term = _host.Node.CurrentTerm;
+                    await stream.WriteAsync(new ClusterBatchData
+                    {
+                        SequenceNumber = batch.SequenceNumber,
+                        Length = batch.Length,
+                        PooledData = batch.PooledData,
+                        LeaderTerm = term,
+                        LeaderId = _host.Node.NodeId,
+                    });
+                    currentSeq = batch.SequenceNumber + 1;
+                    WriteBatch.ReturnPooledBytes(batch.PooledData);
+                }
+            }
+            if (!any)
+            {
+                try { await Task.Delay(50, ct); }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+        return stream.Result();
+    }
+
+    public UnaryResult<bool> ReportLastSyncSequenceNumber(string nodeId, ulong seqNumber)
+    {
+        _host.Node.RecordFollowerProgress(nodeId, seqNumber);
+        _host.OnFollowerProgress(nodeId, seqNumber);
+        return new UnaryResult<bool>(true);
+    }
+
+    public UnaryResult<bool> WriteAsync(WriteRequest req)
+    {
+        // Reject writes that arrive at non-leaders. Clients can introspect with
+        // GetStatusAsync to find the leader.
+        if (_host.Node.Role != RaftRole.Leader)
+            return new UnaryResult<bool>(false);
+        _host.Db.Put(req.Key, req.Value);
+        return new UnaryResult<bool>(true);
+    }
+}

--- a/Tests/ClusterTest/ClusterService.cs
+++ b/Tests/ClusterTest/ClusterService.cs
@@ -78,7 +78,7 @@ public class ClusterService : ServiceBase<IClusterService>, IClusterService
         return new UnaryResult<NodeStatus>(s);
     }
 
-    public async Task<ServerStreamingResult<ClusterFileData>> SyncInitialStateAsync()
+    public async Task<ServerStreamingResult<ClusterFileData>> SyncInitialStateAsync(SnapshotRequest req)
     {
         var stream = GetServerStreamingContext<ClusterFileData>();
         if (_host.IsResyncing) return stream.Result();
@@ -87,13 +87,31 @@ public class ClusterService : ServiceBase<IClusterService>, IClusterService
         var tempPath = Path.Combine(Path.GetTempPath(), "rocksdb_cluster_snap_" + Guid.NewGuid().ToString());
         using (var session = src.GetInitialState(tempPath))
         {
+            // Per-file delta: immutable files the consumer already holds
+            // byte-identically (name + size + SHA-256) are reused; new or
+            // changed files are streamed in full.
+            var plan = ReplicationDelta.Compute(
+                session.GetManifest(),
+                req.Files.Select(f => new ReplicationFileInfo { FileName = f.Name, Size = f.Size, Hash = f.Hash }));
+
+            await stream.WriteAsync(new ClusterFileData
+            {
+                IsPlan = true,
+                KeepFiles = plan.FilesToReuse,
+            });
+
+            // CURRENT names the live MANIFEST, so send it last: a consumer
+            // that dies mid-transfer is left without a CURRENT marker and
+            // will cleanly re-pull instead of opening a half-restored DB.
+            var ordered = plan.FilesToTransfer.OrderBy(f => f == "CURRENT" ? 1 : 0).ToList();
+
             // Chunked so one message stays well below the 4 MB gRPC cap no
             // matter how large the checkpoint SSTs are.
             const int ChunkSize = 1024 * 1024;
             var buffer = new byte[ChunkSize];
-            foreach (var file in session.Files)
+            foreach (var name in ordered)
             {
-                using (file)
+                using (var file = session.OpenFile(name))
                 {
                     bool sentAny = false;
                     int read;

--- a/Tests/ClusterTest/ClusterService.cs
+++ b/Tests/ClusterTest/ClusterService.cs
@@ -84,16 +84,16 @@ public class ClusterService : ServiceBase<IClusterService>, IClusterService
     /// immutable, so hashing the live file is equivalent to hashing the copy a
     /// later checkpoint would hard-link.
     /// </summary>
-    public UnaryResult<List<FileHashResult>> GetFileHashesAsync(List<FileHashQuery> files)
+    public async UnaryResult<List<FileHashResult>> GetFileHashesAsync(List<FileHashQuery> files)
     {
         var result = new List<FileHashResult>(files.Count);
         bool resyncing = _host.IsResyncing;
         foreach (var f in files)
         {
-            string? hash = resyncing ? null : ReplicationDelta.TryHashCandidate(_host.DbPath, f.Name, f.Size);
+            string? hash = resyncing ? null : await ReplicationDelta.TryHashCandidateAsync(_host.DbPath, f.Name, f.Size);
             result.Add(new FileHashResult { Name = f.Name, Found = hash != null, Hash = hash ?? "" });
         }
-        return new UnaryResult<List<FileHashResult>>(result);
+        return result;
     }
 
     public async Task<ServerStreamingResult<ClusterFileData>> SyncInitialStateAsync(SnapshotRequest req)

--- a/Tests/ClusterTest/ClusterService.cs
+++ b/Tests/ClusterTest/ClusterService.cs
@@ -78,6 +78,24 @@ public class ClusterService : ServiceBase<IClusterService>, IClusterService
         return new UnaryResult<NodeStatus>(s);
     }
 
+    /// <summary>
+    /// Hash-request half of the delta transfer: hashes are computed only for
+    /// files this node holds with the exact requested name and size. SSTs are
+    /// immutable, so hashing the live file is equivalent to hashing the copy a
+    /// later checkpoint would hard-link.
+    /// </summary>
+    public UnaryResult<List<FileHashResult>> GetFileHashesAsync(List<FileHashQuery> files)
+    {
+        var result = new List<FileHashResult>(files.Count);
+        bool resyncing = _host.IsResyncing;
+        foreach (var f in files)
+        {
+            string? hash = resyncing ? null : ReplicationDelta.TryHashCandidate(_host.DbPath, f.Name, f.Size);
+            result.Add(new FileHashResult { Name = f.Name, Found = hash != null, Hash = hash ?? "" });
+        }
+        return new UnaryResult<List<FileHashResult>>(result);
+    }
+
     public async Task<ServerStreamingResult<ClusterFileData>> SyncInitialStateAsync(SnapshotRequest req)
     {
         var stream = GetServerStreamingContext<ClusterFileData>();
@@ -87,12 +105,12 @@ public class ClusterService : ServiceBase<IClusterService>, IClusterService
         var tempPath = Path.Combine(Path.GetTempPath(), "rocksdb_cluster_snap_" + Guid.NewGuid().ToString());
         using (var session = src.GetInitialState(tempPath))
         {
-            // Per-file delta: immutable files the consumer already holds
-            // byte-identically (name + size + SHA-256) are reused; new or
-            // changed files are streamed in full.
+            // Per-file delta: the consumer lists immutable files it verified
+            // through GetFileHashesAsync; those are reused on a name + size
+            // match, everything new or changed is streamed in full.
             var plan = ReplicationDelta.Compute(
                 session.GetManifest(),
-                req.Files.Select(f => new ReplicationFileInfo { FileName = f.Name, Size = f.Size, Hash = f.Hash }));
+                req.Files.Select(f => new ReplicationFileInfo { FileName = f.Name, Size = f.Size, Hash = string.Empty }));
 
             await stream.WriteAsync(new ClusterFileData
             {

--- a/Tests/ClusterTest/ClusterService.cs
+++ b/Tests/ClusterTest/ClusterService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -55,16 +56,18 @@ public class ClusterService : ServiceBase<IClusterService>, IClusterService
 
     public UnaryResult<NodeStatus> GetStatusAsync()
     {
+        bool resyncing = _host.IsResyncing;
         var s = new NodeStatus
         {
             NodeId = _host.Node.NodeId,
             Role = _host.Node.Role.ToString(),
             Term = _host.Node.CurrentTerm,
             LeaderId = _host.Node.CurrentLeaderId,
-            LatestSeq = _host.Db.GetLatestSequenceNumber(),
+            LatestSeq = resyncing ? 0 : _host.Db.GetLatestSequenceNumber(),
             CommitSeq = _host.Node.CommitSeq,
             Mode = (int)_host.Node.Mode,
             BootstrapInSyncCount = _host.Node.BootstrapInSyncCount,
+            Resyncing = resyncing,
             Peers = _host.Node.Peers.Select(p => new PeerInfo
             {
                 NodeId = p.Member.NodeId,
@@ -78,21 +81,42 @@ public class ClusterService : ServiceBase<IClusterService>, IClusterService
     public async Task<ServerStreamingResult<ClusterFileData>> SyncInitialStateAsync()
     {
         var stream = GetServerStreamingContext<ClusterFileData>();
+        if (_host.IsResyncing) return stream.Result();
+
         var src = new ReplicationSource(_host.Db);
         var tempPath = Path.Combine(Path.GetTempPath(), "rocksdb_cluster_snap_" + Guid.NewGuid().ToString());
         using (var session = src.GetInitialState(tempPath))
         {
+            // Chunked so one message stays well below the 4 MB gRPC cap no
+            // matter how large the checkpoint SSTs are.
+            const int ChunkSize = 1024 * 1024;
+            var buffer = new byte[ChunkSize];
             foreach (var file in session.Files)
             {
-                using var ms = new MemoryStream();
-                await file.FileStream.CopyToAsync(ms);
-                await stream.WriteAsync(new ClusterFileData
+                using (file)
                 {
-                    FileName = file.FileName,
-                    FileSize = file.FileSize,
-                    Content = ms.ToArray(),
-                });
-                file.Dispose();
+                    bool sentAny = false;
+                    int read;
+                    while ((read = await file.FileStream.ReadAsync(buffer, 0, buffer.Length)) > 0)
+                    {
+                        await stream.WriteAsync(new ClusterFileData
+                        {
+                            FileName = file.FileName,
+                            FileSize = file.FileSize,
+                            Content = buffer.AsSpan(0, read).ToArray(),
+                        });
+                        sentAny = true;
+                    }
+                    if (!sentAny)
+                    {
+                        await stream.WriteAsync(new ClusterFileData
+                        {
+                            FileName = file.FileName,
+                            FileSize = 0,
+                            Content = Array.Empty<byte>(),
+                        });
+                    }
+                }
             }
         }
         return stream.Result();
@@ -108,6 +132,16 @@ public class ClusterService : ServiceBase<IClusterService>, IClusterService
 
         while (!ct.IsCancellationRequested)
         {
+            if (_host.IsResyncing) break;
+
+            // Read the term before the role: if the role still says Leader
+            // afterwards, the term we read belongs to this leadership. A node
+            // that streamed while deposed would otherwise tag batches with the
+            // *new* term while claiming to be the leader, convincing followers
+            // a stale node still leads the cluster.
+            long term = _host.Node.CurrentTerm;
+            if (_host.Node.Role != RaftRole.Leader) break;
+
             bool any = false;
             ulong latest = _host.Db.GetLatestSequenceNumber();
             if (currentSeq <= latest)
@@ -115,13 +149,13 @@ public class ClusterService : ServiceBase<IClusterService>, IClusterService
                 foreach (var batch in src.GetPooledWalUpdates(currentSeq))
                 {
                     any = true;
-                    long term = _host.Node.CurrentTerm;
                     await stream.WriteAsync(new ClusterBatchData
                     {
                         SequenceNumber = batch.SequenceNumber,
                         Length = batch.Length,
                         PooledData = batch.PooledData,
                         LeaderTerm = term,
+                        EntryTerm = _host.Node.GetTermForSeq(batch.SequenceNumber),
                         LeaderId = _host.Node.NodeId,
                     });
                     currentSeq = batch.SequenceNumber + 1;
@@ -144,13 +178,70 @@ public class ClusterService : ServiceBase<IClusterService>, IClusterService
         return new UnaryResult<bool>(true);
     }
 
-    public UnaryResult<bool> WriteAsync(WriteRequest req)
+    public UnaryResult<LogConsistencyResponse> CheckLogConsistencyAsync(LogConsistencyRequest req)
     {
-        // Reject writes that arrive at non-leaders. Clients can introspect with
-        // GetStatusAsync to find the leader.
-        if (_host.Node.Role != RaftRole.Leader)
-            return new UnaryResult<bool>(false);
-        _host.Db.Put(req.Key, req.Value);
+        var r = _host.Node.CheckFollowerLogConsistency(req.FollowerLatestSeq, req.FollowerTermAtLatest);
+        return new UnaryResult<LogConsistencyResponse>(new LogConsistencyResponse
+        {
+            IsLeader = r.IsLeader,
+            Consistent = r.Consistent,
+            Term = r.Term,
+        });
+    }
+
+    public UnaryResult<string> GetRaftTermsAsync()
+    {
+        return new UnaryResult<string>(_host.SerializeTerms());
+    }
+
+    public async UnaryResult<bool> WriteAsync(WriteRequest req)
+    {
+        // Acknowledge only once the write is replicated to a quorum and
+        // committed; an immediate ack would let "committed" writes vanish in
+        // a leader failover, which is precisely what Raft must not allow.
+        return await _host.WriteCommittedAsync(req.Key, req.Value, TimeSpan.FromSeconds(10));
+    }
+
+    public UnaryResult<ReadResponse> ReadAsync(string key)
+    {
+        if (_host.IsResyncing) return new UnaryResult<ReadResponse>(new ReadResponse());
+        var value = _host.Db.Get(key);
+        return new UnaryResult<ReadResponse>(new ReadResponse { Found = value != null, Value = value });
+    }
+
+    public UnaryResult<ChecksumResponse> ChecksumAsync()
+    {
+        if (_host.IsResyncing) return new UnaryResult<ChecksumResponse>(new ChecksumResponse { Available = false });
+
+        // Order-sensitive FNV-1a over every key/value pair. RocksDB iterates
+        // in key order, so converged replicas must produce identical hashes.
+        const ulong FnvOffset = 14695981039346656037UL;
+        const ulong FnvPrime = 1099511628211UL;
+        ulong hash = FnvOffset;
+        long count = 0;
+        using (var it = _host.Db.NewIterator())
+        {
+            for (it.SeekToFirst(); it.Valid(); it.Next())
+            {
+                foreach (var b in it.Key()) { hash ^= b; hash *= FnvPrime; }
+                hash ^= 0xFF; hash *= FnvPrime;
+                foreach (var b in it.Value()) { hash ^= b; hash *= FnvPrime; }
+                hash ^= 0xFE; hash *= FnvPrime;
+                count++;
+            }
+        }
+        return new UnaryResult<ChecksumResponse>(new ChecksumResponse
+        {
+            Available = true,
+            KeyCount = count,
+            Hash = hash,
+            LatestSeq = _host.Db.GetLatestSequenceNumber(),
+        });
+    }
+
+    public UnaryResult<bool> SetWriteLoadAsync(bool enabled)
+    {
+        _host.WriteLoadEnabled = enabled;
         return new UnaryResult<bool>(true);
     }
 }

--- a/Tests/ClusterTest/ClusterTest.csproj
+++ b/Tests/ClusterTest/ClusterTest.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MagicOnion.Client" Version="7.10.0" />
+    <PackageReference Include="MagicOnion.Server" Version="7.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\csharp\RocksDbSharp.csproj" />
+    <PackageReference Include="RocksDB" Version="10.4.2.64152" ExcludeAssets="compile;runtime" PrivateAssets="all" GeneratePathProperty="true" />
+    <None Include="$(NuGetPackageRoot)RocksDB\10.4.2.64152\runtimes\**\*" CopyToOutputDirectory="PreserveNewest" Visible="false" TargetPath="runtimes\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+</Project>

--- a/Tests/ClusterTest/ClusterTest.csproj
+++ b/Tests/ClusterTest/ClusterTest.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RocksDbPackageVersion>10.4.2.64152</RocksDbPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,8 +14,19 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- We need the local RocksDbSharp project for the C# API. -->
     <ProjectReference Include="..\..\csharp\RocksDbSharp.csproj" />
-    <PackageReference Include="RocksDB" Version="10.4.2.64152" ExcludeAssets="compile;runtime" PrivateAssets="all" GeneratePathProperty="true" />
-    <None Include="$(NuGetPackageRoot)RocksDB\10.4.2.64152\runtimes\**\*" CopyToOutputDirectory="PreserveNewest" Visible="false" TargetPath="runtimes\%(RecursiveDir)%(Filename)%(Extension)" />
+
+    <!-- The local project declares <PackageId>RocksDB</PackageId>, so a normal
+         <PackageReference Include="RocksDB" .../> is resolved against it and
+         the public NuGet package is never fetched. PackageDownload bypasses
+         that substitution and downloads the real package into the global
+         NuGet cache so its per-RID native binaries can be copied below. -->
+    <PackageDownload Include="RocksDB" Version="[$(RocksDbPackageVersion)]" />
+
+    <None Include="$(NuGetPackageRoot)rocksdb\$(RocksDbPackageVersion)\runtimes\**\*"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="false"
+          TargetPath="runtimes\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/Tests/ClusterTest/IClusterService.cs
+++ b/Tests/ClusterTest/IClusterService.cs
@@ -21,6 +21,7 @@ public interface IClusterService : IService<IClusterService>
     UnaryResult<NodeStatus> GetStatusAsync();
 
     // ---- Snapshot + WAL stream (reused from replication path) ----
+    UnaryResult<List<FileHashResult>> GetFileHashesAsync(List<FileHashQuery> files);
     Task<ServerStreamingResult<ClusterFileData>> SyncInitialStateAsync(SnapshotRequest req);
     Task<ServerStreamingResult<ClusterBatchData>> SyncUpdatesAsync(SyncUpdatesRequest req);
     UnaryResult<bool> ReportLastSyncSequenceNumber(string nodeId, ulong seqNumber);
@@ -122,10 +123,31 @@ public class PeerInfo
 }
 
 /// <summary>
+/// Hash request for one candidate file. The source computes a hash only when
+/// it holds an immutable file with this exact name *and* size - files that
+/// cannot match are never hashed on either side.
+/// </summary>
+[MessagePackObject]
+public class FileHashQuery
+{
+    [Key(0)] public string Name { get; set; } = "";
+    [Key(1)] public long Size { get; set; }
+}
+
+[MessagePackObject]
+public class FileHashResult
+{
+    [Key(0)] public string Name { get; set; } = "";
+    [Key(1)] public bool Found { get; set; }
+    [Key(2)] public string Hash { get; set; } = "";
+}
+
+/// <summary>
 /// The consumer's side of a per-file delta snapshot transfer: the immutable
-/// files (.sst / .blob) it already holds, with sizes and content hashes. The
-/// source reuses matching files and only streams the new or changed ones, in
-/// full. An empty inventory degrades to a complete snapshot transfer.
+/// files (.sst / .blob) it already holds AND has verified against the source
+/// through the <see cref="IClusterService.GetFileHashesAsync"/> exchange.
+/// The source reuses these and only streams new or changed files, in full.
+/// An empty inventory degrades to a complete snapshot transfer.
 /// </summary>
 [MessagePackObject]
 public class SnapshotRequest
@@ -138,7 +160,6 @@ public class FileInventoryItem
 {
     [Key(0)] public string Name { get; set; } = "";
     [Key(1)] public long Size { get; set; }
-    [Key(2)] public string Hash { get; set; } = "";
 }
 
 /// <summary>

--- a/Tests/ClusterTest/IClusterService.cs
+++ b/Tests/ClusterTest/IClusterService.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Grpc.Core;
+using MagicOnion;
+using MagicOnion.Serialization;
+using MessagePack;
+using MessagePack.Formatters;
+
+namespace ClusterTest;
+
+public interface IClusterService : IService<IClusterService>
+{
+    // ---- Raft RPCs ----
+    UnaryResult<RequestVoteResponse> RequestVoteAsync(RequestVoteRequest req);
+    UnaryResult<AppendEntriesResponse> HeartbeatAsync(HeartbeatRequest req);
+
+    // ---- Cluster join / status ----
+    UnaryResult<JoinResponse> JoinAsync(JoinRequest req);
+    UnaryResult<NodeStatus> GetStatusAsync();
+
+    // ---- Snapshot + WAL stream (reused from replication path) ----
+    Task<ServerStreamingResult<ClusterFileData>> SyncInitialStateAsync();
+    Task<ServerStreamingResult<ClusterBatchData>> SyncUpdatesAsync(SyncUpdatesRequest req);
+    UnaryResult<bool> ReportLastSyncSequenceNumber(string nodeId, ulong seqNumber);
+
+    // ---- Testing helpers ----
+    UnaryResult<bool> WriteAsync(WriteRequest req);
+}
+
+// =============== DTOs ===============
+
+[MessagePackObject]
+public class RequestVoteRequest
+{
+    [Key(0)] public long Term { get; set; }
+    [Key(1)] public string CandidateId { get; set; } = "";
+    [Key(2)] public ulong LastLogSeq { get; set; }
+    [Key(3)] public long LastLogTerm { get; set; }
+}
+
+[MessagePackObject]
+public class RequestVoteResponse
+{
+    [Key(0)] public long Term { get; set; }
+    [Key(1)] public bool VoteGranted { get; set; }
+}
+
+[MessagePackObject]
+public class HeartbeatRequest
+{
+    [Key(0)] public long Term { get; set; }
+    [Key(1)] public string LeaderId { get; set; } = "";
+    [Key(2)] public ulong PrevLogSeq { get; set; }
+    [Key(3)] public long PrevLogTerm { get; set; }
+    [Key(4)] public ulong LeaderCommit { get; set; }
+    [Key(5)] public int LeaderMode { get; set; }
+}
+
+[MessagePackObject]
+public class AppendEntriesResponse
+{
+    [Key(0)] public long Term { get; set; }
+    [Key(1)] public bool Success { get; set; }
+    [Key(2)] public ulong LastSeq { get; set; }
+    [Key(3)] public string? Reason { get; set; }
+}
+
+[MessagePackObject]
+public class JoinRequest
+{
+    [Key(0)] public string NodeId { get; set; } = "";
+    [Key(1)] public string Endpoint { get; set; } = "";
+}
+
+[MessagePackObject]
+public class JoinResponse
+{
+    [Key(0)] public bool Accepted { get; set; }
+    [Key(1)] public string LeaderId { get; set; } = "";
+    [Key(2)] public long Term { get; set; }
+    [Key(3)] public int Mode { get; set; }
+    [Key(4)] public List<ClusterMemberInfo> Members { get; set; } = new();
+}
+
+[MessagePackObject]
+public class ClusterMemberInfo
+{
+    [Key(0)] public string NodeId { get; set; } = "";
+    [Key(1)] public string Endpoint { get; set; } = "";
+}
+
+[MessagePackObject]
+public class NodeStatus
+{
+    [Key(0)] public string NodeId { get; set; } = "";
+    [Key(1)] public string Role { get; set; } = "";
+    [Key(2)] public long Term { get; set; }
+    [Key(3)] public string? LeaderId { get; set; }
+    [Key(4)] public ulong LatestSeq { get; set; }
+    [Key(5)] public ulong CommitSeq { get; set; }
+    [Key(6)] public int Mode { get; set; }
+    [Key(7)] public List<PeerInfo> Peers { get; set; } = new();
+    [Key(8)] public int BootstrapInSyncCount { get; set; }
+}
+
+[MessagePackObject]
+public class PeerInfo
+{
+    [Key(0)] public string NodeId { get; set; } = "";
+    [Key(1)] public ulong MatchSeq { get; set; }
+    [Key(2)] public bool Reachable { get; set; }
+}
+
+[MessagePackObject]
+public class ClusterFileData
+{
+    [Key(0)] public string FileName { get; set; } = string.Empty;
+    [Key(1)] public ulong FileSize { get; set; }
+    [Key(2)] public byte[] Content { get; set; } = Array.Empty<byte>();
+}
+
+[MessagePackObject]
+public class SyncUpdatesRequest
+{
+    [Key(0)] public string NodeId { get; set; } = "";
+    [Key(1)] public ulong StartSeq { get; set; }
+}
+
+[MessagePackObject]
+[MessagePackFormatter(typeof(PooledClusterBatchDataSerializer))]
+public class ClusterBatchData
+{
+    [Key(0)] public ulong SequenceNumber { get; set; }
+    [Key(1)] public int Length { get; set; }
+    [Key(2)] public long LeaderTerm { get; set; }
+    [Key(3)] public string LeaderId { get; set; } = "";
+    [Key(4)] public byte[] PooledData { get; set; } = Array.Empty<byte>();
+
+    [IgnoreMember] public ReadOnlySpan<byte> Data => PooledData.AsSpan(0, Length);
+
+    public void ReturnToPool()
+    {
+        if (PooledData.Length > 0) ArrayPool<byte>.Shared.Return(PooledData);
+        PooledData = Array.Empty<byte>();
+    }
+}
+
+public class PooledClusterBatchDataSerializer : IMessagePackFormatter<ClusterBatchData>
+{
+    public ClusterBatchData Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        var d = new ClusterBatchData();
+        d.SequenceNumber = reader.ReadUInt64();
+        d.Length = reader.ReadInt32();
+        d.LeaderTerm = reader.ReadInt64();
+        d.LeaderId = reader.ReadString() ?? "";
+        var pooled = ArrayPool<byte>.Shared.Rent(d.Length);
+        var raw = reader.ReadRaw(d.Length);
+        raw.CopyTo(pooled.AsSpan(0, d.Length));
+        d.PooledData = pooled;
+        return d;
+    }
+
+    public void Serialize(ref MessagePackWriter writer, ClusterBatchData value, MessagePackSerializerOptions options)
+    {
+        writer.WriteUInt64(value.SequenceNumber);
+        writer.WriteInt32(value.Length);
+        writer.WriteInt64(value.LeaderTerm);
+        writer.Write(value.LeaderId);
+        writer.WriteRaw(value.PooledData.AsSpan(0, value.Length));
+    }
+}
+
+[MessagePackObject]
+public class WriteRequest
+{
+    [Key(0)] public string Key { get; set; } = "";
+    [Key(1)] public string Value { get; set; } = "";
+}

--- a/Tests/ClusterTest/IClusterService.cs
+++ b/Tests/ClusterTest/IClusterService.cs
@@ -25,8 +25,15 @@ public interface IClusterService : IService<IClusterService>
     Task<ServerStreamingResult<ClusterBatchData>> SyncUpdatesAsync(SyncUpdatesRequest req);
     UnaryResult<bool> ReportLastSyncSequenceNumber(string nodeId, ulong seqNumber);
 
+    // ---- Log consistency / resync ----
+    UnaryResult<LogConsistencyResponse> CheckLogConsistencyAsync(LogConsistencyRequest req);
+    UnaryResult<string> GetRaftTermsAsync();
+
     // ---- Testing helpers ----
     UnaryResult<bool> WriteAsync(WriteRequest req);
+    UnaryResult<ReadResponse> ReadAsync(string key);
+    UnaryResult<ChecksumResponse> ChecksumAsync();
+    UnaryResult<bool> SetWriteLoadAsync(bool enabled);
 }
 
 // =============== DTOs ===============
@@ -103,6 +110,7 @@ public class NodeStatus
     [Key(6)] public int Mode { get; set; }
     [Key(7)] public List<PeerInfo> Peers { get; set; } = new();
     [Key(8)] public int BootstrapInSyncCount { get; set; }
+    [Key(9)] public bool Resyncing { get; set; }
 }
 
 [MessagePackObject]
@@ -113,6 +121,11 @@ public class PeerInfo
     [Key(2)] public bool Reachable { get; set; }
 }
 
+/// <summary>
+/// One chunk of one checkpoint file. Files are streamed in contiguous chunks
+/// (a new FileName starts a new file) so a single message never exceeds the
+/// gRPC max-message size regardless of how large the SST files are.
+/// </summary>
 [MessagePackObject]
 public class ClusterFileData
 {
@@ -129,6 +142,38 @@ public class SyncUpdatesRequest
 }
 
 [MessagePackObject]
+public class LogConsistencyRequest
+{
+    [Key(0)] public string NodeId { get; set; } = "";
+    [Key(1)] public ulong FollowerLatestSeq { get; set; }
+    [Key(2)] public long FollowerTermAtLatest { get; set; }
+}
+
+[MessagePackObject]
+public class LogConsistencyResponse
+{
+    [Key(0)] public bool IsLeader { get; set; }
+    [Key(1)] public bool Consistent { get; set; }
+    [Key(2)] public long Term { get; set; }
+}
+
+[MessagePackObject]
+public class ReadResponse
+{
+    [Key(0)] public bool Found { get; set; }
+    [Key(1)] public string? Value { get; set; }
+}
+
+[MessagePackObject]
+public class ChecksumResponse
+{
+    [Key(0)] public bool Available { get; set; }
+    [Key(1)] public long KeyCount { get; set; }
+    [Key(2)] public ulong Hash { get; set; }
+    [Key(3)] public ulong LatestSeq { get; set; }
+}
+
+[MessagePackObject]
 [MessagePackFormatter(typeof(PooledClusterBatchDataSerializer))]
 public class ClusterBatchData
 {
@@ -136,7 +181,15 @@ public class ClusterBatchData
     [Key(1)] public int Length { get; set; }
     [Key(2)] public long LeaderTerm { get; set; }
     [Key(3)] public string LeaderId { get; set; } = "";
-    [Key(4)] public byte[] PooledData { get; set; } = Array.Empty<byte>();
+    /// <summary>
+    /// Term of this batch itself (from the leader's term map), as opposed to
+    /// <see cref="LeaderTerm"/> which is the leader's current term. A follower
+    /// catching up replays old batches whose entry term is lower than the
+    /// leader's current term; recording LeaderTerm for them would corrupt the
+    /// follower's term map and break the election up-to-date comparison.
+    /// </summary>
+    [Key(4)] public long EntryTerm { get; set; }
+    [Key(5)] public byte[] PooledData { get; set; } = Array.Empty<byte>();
 
     [IgnoreMember] public ReadOnlySpan<byte> Data => PooledData.AsSpan(0, Length);
 
@@ -156,7 +209,8 @@ public class PooledClusterBatchDataSerializer : IMessagePackFormatter<ClusterBat
         d.Length = reader.ReadInt32();
         d.LeaderTerm = reader.ReadInt64();
         d.LeaderId = reader.ReadString() ?? "";
-        var pooled = ArrayPool<byte>.Shared.Rent(d.Length);
+        d.EntryTerm = reader.ReadInt64();
+        var pooled = ArrayPool<byte>.Shared.Rent(Math.Max(1, d.Length));
         var raw = reader.ReadRaw(d.Length);
         raw.CopyTo(pooled.AsSpan(0, d.Length));
         d.PooledData = pooled;
@@ -169,6 +223,7 @@ public class PooledClusterBatchDataSerializer : IMessagePackFormatter<ClusterBat
         writer.WriteInt32(value.Length);
         writer.WriteInt64(value.LeaderTerm);
         writer.Write(value.LeaderId);
+        writer.WriteInt64(value.EntryTerm);
         writer.WriteRaw(value.PooledData.AsSpan(0, value.Length));
     }
 }

--- a/Tests/ClusterTest/IClusterService.cs
+++ b/Tests/ClusterTest/IClusterService.cs
@@ -21,7 +21,7 @@ public interface IClusterService : IService<IClusterService>
     UnaryResult<NodeStatus> GetStatusAsync();
 
     // ---- Snapshot + WAL stream (reused from replication path) ----
-    Task<ServerStreamingResult<ClusterFileData>> SyncInitialStateAsync();
+    Task<ServerStreamingResult<ClusterFileData>> SyncInitialStateAsync(SnapshotRequest req);
     Task<ServerStreamingResult<ClusterBatchData>> SyncUpdatesAsync(SyncUpdatesRequest req);
     UnaryResult<bool> ReportLastSyncSequenceNumber(string nodeId, ulong seqNumber);
 
@@ -122,9 +122,32 @@ public class PeerInfo
 }
 
 /// <summary>
-/// One chunk of one checkpoint file. Files are streamed in contiguous chunks
-/// (a new FileName starts a new file) so a single message never exceeds the
-/// gRPC max-message size regardless of how large the SST files are.
+/// The consumer's side of a per-file delta snapshot transfer: the immutable
+/// files (.sst / .blob) it already holds, with sizes and content hashes. The
+/// source reuses matching files and only streams the new or changed ones, in
+/// full. An empty inventory degrades to a complete snapshot transfer.
+/// </summary>
+[MessagePackObject]
+public class SnapshotRequest
+{
+    [Key(0)] public List<FileInventoryItem> Files { get; set; } = new();
+}
+
+[MessagePackObject]
+public class FileInventoryItem
+{
+    [Key(0)] public string Name { get; set; } = "";
+    [Key(1)] public long Size { get; set; }
+    [Key(2)] public string Hash { get; set; } = "";
+}
+
+/// <summary>
+/// One message of the snapshot stream. The first message is the delta plan
+/// (<see cref="IsPlan"/> = true, <see cref="KeepFiles"/> lists the local files
+/// the consumer may reuse; everything else local must be deleted). Subsequent
+/// messages are chunks of checkpoint files - a new FileName starts a new file -
+/// so a single message never exceeds the gRPC max-message size regardless of
+/// how large the SST files are.
 /// </summary>
 [MessagePackObject]
 public class ClusterFileData
@@ -132,6 +155,8 @@ public class ClusterFileData
     [Key(0)] public string FileName { get; set; } = string.Empty;
     [Key(1)] public ulong FileSize { get; set; }
     [Key(2)] public byte[] Content { get; set; } = Array.Empty<byte>();
+    [Key(3)] public bool IsPlan { get; set; }
+    [Key(4)] public List<string> KeepFiles { get; set; } = new();
 }
 
 [MessagePackObject]

--- a/Tests/ClusterTest/Program.cs
+++ b/Tests/ClusterTest/Program.cs
@@ -18,8 +18,7 @@ internal static class Program
     {
         if (args.Length == 0 || args[0] == "coordinator")
         {
-            await new Coordinator().RunAsync(args.Skip(1).ToArray());
-            return 0;
+            return await new Coordinator().RunAsync(args.Skip(1).ToArray());
         }
 
         if (args[0] == "node")
@@ -32,34 +31,43 @@ internal static class Program
             await host.StartAsync();
 
             // The "writer" role drives traffic when this node is the leader.
+            // Every Put goes through TryWriteAsLeader so a deposed leader stops
+            // writing immediately instead of polluting its local WAL.
             _ = Task.Run(async () =>
             {
                 long counter = 0;
                 while (true)
                 {
-                    if (host.Node.Role == RocksDbSharp.RaftRole.Leader)
+                    if (host.WriteLoadEnabled)
                     {
                         for (int i = 0; i < 200; i++)
                         {
-                            string key = $"{host.Node.NodeId}_{counter++:D012}";
-                            host.Db.Put(key, $"{Stopwatch.GetTimestamp()}");
+                            string key = $"{host.Node.NodeId}_{counter:D012}";
+                            if (!host.TryWriteAsLeader(key, $"{Stopwatch.GetTimestamp()}")) break;
+                            counter++;
                         }
                     }
                     await Task.Delay(50);
                 }
             });
 
-            // Console reporting once per second
+            // Console reporting once per two seconds
             _ = Task.Run(async () =>
             {
                 while (true)
                 {
-                    Console.WriteLine($"[{DateTimeOffset.UtcNow:HH:mm:ss.fff} {host.Node.NodeId}] " +
-                                      $"role={host.Node.Role} term={host.Node.CurrentTerm} " +
-                                      $"leader={host.Node.CurrentLeaderId} " +
-                                      $"latest={host.Db.GetLatestSequenceNumber():n0} " +
-                                      $"commit={host.Node.CommitSeq:n0} mode={host.Node.Mode} " +
-                                      $"bootSync={host.Node.BootstrapInSyncCount}");
+                    try
+                    {
+                        ulong latest = host.IsResyncing ? 0 : host.Db.GetLatestSequenceNumber();
+                        Console.WriteLine($"[{DateTimeOffset.UtcNow:HH:mm:ss.fff} {host.Node.NodeId}] " +
+                                          $"role={host.Node.Role} term={host.Node.CurrentTerm} " +
+                                          $"leader={host.Node.CurrentLeaderId} " +
+                                          $"latest={latest:n0} " +
+                                          $"commit={host.Node.CommitSeq:n0} mode={host.Node.Mode} " +
+                                          $"bootSync={host.Node.BootstrapInSyncCount}" +
+                                          (host.IsResyncing ? " RESYNCING" : ""));
+                    }
+                    catch { }
                     await Task.Delay(2000);
                 }
             });
@@ -80,6 +88,12 @@ internal sealed class Coordinator
     private readonly string _exePath;
     private readonly string _argsPrefix;
     private readonly List<NodeProcess> _processes = new();
+
+    // ---- Raft invariant tracking (fed by every status poll) ----
+    private readonly object _invariantGate = new();
+    private readonly Dictionary<string, long> _highestTermSeen = new();   // nodeId -> term
+    private readonly Dictionary<long, string> _leaderByTerm = new();      // term -> leaderId
+    private readonly List<string> _violations = new();
 
     public Coordinator()
     {
@@ -108,7 +122,7 @@ internal sealed class Coordinator
         }
     }
 
-    public async Task RunAsync(string[] args)
+    public async Task<int> RunAsync(string[] args)
     {
         string scenario = args.Length > 0 ? args[0] : "all";
 
@@ -129,8 +143,15 @@ internal sealed class Coordinator
                     break;
                 default:
                     Console.Error.WriteLine($"Unknown scenario '{scenario}'. Use: election | crash | hang | rejoin | all");
-                    return;
+                    return 2;
             }
+            Log("ALL SCENARIOS PASSED");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Log($"FAILED: {ex.Message}");
+            return 1;
         }
         finally
         {
@@ -145,13 +166,19 @@ internal sealed class Coordinator
     private async Task ScenarioElectionAsync()
     {
         Log("=== scenario: bootstrap → cluster mode promotion ===");
-        var cluster = StartCluster(3, scenarioName: "election");
+        var cluster = StartCluster(3, scenarioName: "election", basePort: 51000);
 
         await WaitForClusterModeAsync(cluster, TimeSpan.FromSeconds(45));
         Log("cluster has switched to Cluster mode");
 
         var leader = await WaitForLeaderAsync(cluster, TimeSpan.FromSeconds(20));
         Log($"current leader = {leader}");
+
+        // Committed (quorum-acknowledged) writes must succeed on the leader.
+        var keys = await WriteCommittedKeysAsync(EndpointOf(cluster, leader), "committed_election", 50);
+        Log($"wrote {keys.Count} committed keys");
+
+        await ValidateClusterConsistencyAsync(cluster);
 
         KillAll();
         await Task.Delay(500);
@@ -160,10 +187,15 @@ internal sealed class Coordinator
     private async Task ScenarioLeaderCrashAsync()
     {
         Log("=== scenario: leader crash → re-election ===");
-        var cluster = StartCluster(3, scenarioName: "crash");
+        var cluster = StartCluster(3, scenarioName: "crash", basePort: 51010);
         await WaitForClusterModeAsync(cluster, TimeSpan.FromSeconds(45));
         var leader = await WaitForLeaderAsync(cluster, TimeSpan.FromSeconds(20));
         Log($"initial leader = {leader}");
+
+        // These writes are acknowledged as committed, so Raft's Leader
+        // Completeness property says they must survive the crash.
+        var keys = await WriteCommittedKeysAsync(EndpointOf(cluster, leader), "committed_crash", 100);
+        Log($"wrote {keys.Count} committed keys on {leader}");
 
         var leaderProc = cluster.First(c => c.Config.NodeId == leader);
         Log($"killing leader {leader} (pid {leaderProc.Process.Id})");
@@ -175,6 +207,12 @@ internal sealed class Coordinator
         var newLeader = await WaitForLeaderAsync(remaining, TimeSpan.FromSeconds(30), differentFrom: leader);
         Log($"new leader = {newLeader}");
 
+        await VerifyKeysPresentAsync(EndpointOf(remaining, newLeader), keys,
+            $"all committed writes survive the failover to {newLeader}");
+        Log("all committed writes survived the failover");
+
+        await ValidateClusterConsistencyAsync(remaining);
+
         KillAll();
         await Task.Delay(500);
     }
@@ -182,23 +220,29 @@ internal sealed class Coordinator
     private async Task ScenarioLeaderHangAsync()
     {
         Log("=== scenario: leader hang (SIGSTOP) → re-election → SIGCONT ===");
-        var cluster = StartCluster(3, scenarioName: "hang");
+        var cluster = StartCluster(3, scenarioName: "hang", basePort: 51020);
         await WaitForClusterModeAsync(cluster, TimeSpan.FromSeconds(45));
         var leader = await WaitForLeaderAsync(cluster, TimeSpan.FromSeconds(20));
         Log($"initial leader = {leader}");
+
+        var keysBefore = await WriteCommittedKeysAsync(EndpointOf(cluster, leader), "committed_prehang", 50);
 
         var leaderProc = cluster.First(c => c.Config.NodeId == leader);
         Log($"freezing leader {leader} (pid {leaderProc.Process.Id})");
         if (!StopProcess(leaderProc.Process))
         {
-            Log("SIGSTOP unavailable on this OS; falling back to Kill");
-            leaderProc.Process.Kill(entireProcessTree: true);
+            Log("SIGSTOP unavailable on this OS; skipping the hang scenario");
+            KillAll();
+            return;
         }
 
         // followers should elect a new leader once the heartbeat lapses
         var remaining = cluster.Where(c => c.Config.NodeId != leader).ToList();
         var newLeader = await WaitForLeaderAsync(remaining, TimeSpan.FromSeconds(30), differentFrom: leader);
         Log($"new leader (while old is frozen) = {newLeader}");
+
+        var keysAfter = await WriteCommittedKeysAsync(EndpointOf(remaining, newLeader), "committed_posthang", 50);
+        Log($"wrote {keysAfter.Count} committed keys on the new leader");
 
         // resume the frozen node and confirm it becomes a follower of the new leader
         Log($"resuming {leader}");
@@ -210,6 +254,15 @@ internal sealed class Coordinator
             return s != null && s.LeaderId == newLeader && s.Role == "Follower";
         }, TimeSpan.FromSeconds(20), $"resumed node {leader} accepts {newLeader} as leader");
 
+        await VerifyKeysPresentAsync(EndpointOf(cluster, newLeader), keysBefore.Concat(keysAfter).ToList(),
+            "committed writes from before and after the hang are all present");
+
+        // The resumed node may have accepted uncommitted writes while it still
+        // believed it was the leader; it must detect the divergence, resync,
+        // and converge to a byte-identical copy. The consistency check below
+        // proves both the resync path and the loss of unacknowledged writes.
+        await ValidateClusterConsistencyAsync(cluster, timeout: TimeSpan.FromSeconds(90));
+
         KillAll();
         await Task.Delay(500);
     }
@@ -217,7 +270,7 @@ internal sealed class Coordinator
     private async Task ScenarioFollowerCrashRejoinAsync()
     {
         Log("=== scenario: follower crash → restart → catch-up ===");
-        var cluster = StartCluster(3, scenarioName: "rejoin");
+        var cluster = StartCluster(3, scenarioName: "rejoin", basePort: 51030);
         await WaitForClusterModeAsync(cluster, TimeSpan.FromSeconds(45));
         var leader = await WaitForLeaderAsync(cluster, TimeSpan.FromSeconds(20));
 
@@ -233,23 +286,168 @@ internal sealed class Coordinator
         await WaitUntilAsync(async () =>
         {
             var s = await TryGetStatusAsync(follower.Config.Endpoint);
-            if (s == null) return false;
-            var leaderStatus = await TryGetStatusAsync(cluster.First(c => c.Config.NodeId == leader).Config.Endpoint);
+            if (s == null || s.Resyncing) return false;
+            var leaderStatus = await TryGetStatusAsync(EndpointOf(cluster, leader));
             if (leaderStatus == null) return false;
             return s.LatestSeq + 5000 >= leaderStatus.LatestSeq;
         }, TimeSpan.FromSeconds(60), $"follower {follower.Config.NodeId} caught back up");
+
+        var alive = cluster.Where(c => !c.Process.HasExited).ToList();
+        await ValidateClusterConsistencyAsync(alive);
 
         KillAll();
         await Task.Delay(500);
     }
 
     // -----------------------------------------------------------------------
+    // Raft validation helpers
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Fed with every status poll. Checks the observable Raft invariants:
+    ///  - Election Safety: at most one leader per term;
+    ///  - terms are monotonically non-decreasing on every node;
+    ///  - the commit index never exceeds the log tail.
+    /// Violations are recorded and surfaced at the next validation point
+    /// (throwing here would be swallowed by the polling loops).
+    /// </summary>
+    private void CheckInvariants(NodeStatus s)
+    {
+        lock (_invariantGate)
+        {
+            if (_highestTermSeen.TryGetValue(s.NodeId, out var prev) && s.Term < prev)
+                _violations.Add($"term went backwards on {s.NodeId}: {prev} -> {s.Term}");
+            _highestTermSeen[s.NodeId] = Math.Max(s.Term, _highestTermSeen.GetValueOrDefault(s.NodeId));
+
+            if (s.Role == "Leader")
+            {
+                if (_leaderByTerm.TryGetValue(s.Term, out var other) && other != s.NodeId)
+                    _violations.Add($"ELECTION SAFETY VIOLATION: two leaders in term {s.Term}: {other} and {s.NodeId}");
+                _leaderByTerm[s.Term] = s.NodeId;
+            }
+
+            if (!s.Resyncing && s.CommitSeq > s.LatestSeq)
+                _violations.Add($"commit ({s.CommitSeq}) ahead of log tail ({s.LatestSeq}) on {s.NodeId}");
+        }
+    }
+
+    private void AssertNoViolations()
+    {
+        lock (_invariantGate)
+        {
+            if (_violations.Count > 0)
+                throw new InvalidOperationException("Raft invariant violations:\n  " + string.Join("\n  ", _violations.Distinct()));
+        }
+    }
+
+    private async Task<List<string>> WriteCommittedKeysAsync(string leaderEndpoint, string prefix, int count)
+    {
+        var keys = new List<string>(count);
+        using var ch = GrpcChannel.ForAddress(leaderEndpoint);
+        var client = MagicOnionClient.Create<IClusterService>(ch);
+        for (int i = 0; i < count; i++)
+        {
+            string key = $"{prefix}_{i:D6}";
+            bool ok = await client.WriteAsync(new WriteRequest { Key = key, Value = $"v{i}" });
+            if (!ok) throw new InvalidOperationException($"committed write '{key}' was not acknowledged by {leaderEndpoint}");
+            keys.Add(key);
+        }
+        return keys;
+    }
+
+    private async Task VerifyKeysPresentAsync(string endpoint, List<string> keys, string label)
+    {
+        using var ch = GrpcChannel.ForAddress(endpoint);
+        var client = MagicOnionClient.Create<IClusterService>(ch);
+        var missing = new List<string>();
+        foreach (var key in keys)
+        {
+            var r = await client.ReadAsync(key);
+            if (!r.Found) missing.Add(key);
+        }
+        if (missing.Count > 0)
+            throw new InvalidOperationException(
+                $"DURABILITY VIOLATION ({label}): {missing.Count}/{keys.Count} committed keys missing, e.g. {missing[0]}");
+    }
+
+    /// <summary>
+    /// Quiesces the write load, waits for every node to converge to the same
+    /// log tail with a fully advanced commit index, then compares whole-DB
+    /// checksums. Identical checksums on all replicas is the State Machine
+    /// Safety property made observable.
+    /// </summary>
+    private async Task ValidateClusterConsistencyAsync(IEnumerable<NodeProcess> nodes, TimeSpan? timeout = null)
+    {
+        var list = nodes.Where(n => !n.Process.HasExited).ToList();
+        Log($"validating consistency across {list.Count} nodes...");
+
+        foreach (var n in list)
+        {
+            try
+            {
+                using var ch = GrpcChannel.ForAddress(n.Config.Endpoint);
+                var client = MagicOnionClient.Create<IClusterService>(ch);
+                await client.SetWriteLoadAsync(false);
+            }
+            catch { }
+        }
+
+        await WaitUntilAsync(async () =>
+        {
+            var statuses = new List<NodeStatus>();
+            foreach (var n in list)
+            {
+                var s = await TryGetStatusAsync(n.Config.Endpoint);
+                if (s == null || s.Resyncing) return false;
+                statuses.Add(s);
+            }
+            if (statuses.Count(s => s.Role == "Leader") != 1) return false;
+            if (statuses.Select(s => s.LatestSeq).Distinct().Count() != 1) return false;
+            // commit must catch up to the tail once the cluster is quiescent
+            return statuses.All(s => s.CommitSeq == s.LatestSeq);
+        }, timeout ?? TimeSpan.FromSeconds(45), "all nodes converged to the same committed log tail");
+
+        var sums = new List<(string NodeId, ChecksumResponse Sum)>();
+        foreach (var n in list)
+        {
+            using var ch = GrpcChannel.ForAddress(n.Config.Endpoint);
+            var client = MagicOnionClient.Create<IClusterService>(ch);
+            var sum = await client.ChecksumAsync();
+            if (!sum.Available) throw new InvalidOperationException($"checksum unavailable on {n.Config.NodeId}");
+            sums.Add((n.Config.NodeId, sum));
+        }
+
+        var first = sums[0];
+        foreach (var (nodeId, sum) in sums.Skip(1))
+        {
+            if (sum.Hash != first.Sum.Hash || sum.KeyCount != first.Sum.KeyCount)
+                throw new InvalidOperationException(
+                    "STATE MACHINE SAFETY VIOLATION: replicas diverge: " +
+                    string.Join(", ", sums.Select(x => $"{x.NodeId}: {x.Sum.KeyCount} keys / {x.Sum.Hash:x16}")));
+        }
+
+        AssertNoViolations();
+        Log($"consistency OK: {first.Sum.KeyCount:n0} keys, checksum {first.Sum.Hash:x16}, on {sums.Count} nodes");
+    }
+
+    private static string EndpointOf(IEnumerable<NodeProcess> cluster, string nodeId) =>
+        cluster.First(c => c.Config.NodeId == nodeId).Config.Endpoint;
+
+    // -----------------------------------------------------------------------
     // Cluster bootstrap helpers
     // -----------------------------------------------------------------------
 
-    private List<NodeProcess> StartCluster(int nodeCount, string scenarioName)
+    private List<NodeProcess> StartCluster(int nodeCount, string scenarioName, int basePort)
     {
-        int basePort = 51000 + (Math.Abs(scenarioName.GetHashCode()) % 50) * 10;
+        // Raft invariants hold within one cluster; each scenario boots a fresh
+        // cluster whose terms restart at 1, so the trackers must restart too.
+        lock (_invariantGate)
+        {
+            _highestTermSeen.Clear();
+            _leaderByTerm.Clear();
+            _violations.Clear();
+        }
+
         var members = new List<MemberConfig>();
         for (int i = 0; i < nodeCount; i++)
         {
@@ -369,13 +567,15 @@ internal sealed class Coordinator
         throw new TimeoutException($"Timeout waiting for: {label}");
     }
 
-    private static async Task<NodeStatus?> TryGetStatusAsync(string endpoint)
+    private async Task<NodeStatus?> TryGetStatusAsync(string endpoint)
     {
         try
         {
             using var ch = GrpcChannel.ForAddress(endpoint);
             var client = MagicOnionClient.Create<IClusterService>(ch);
-            return await client.GetStatusAsync();
+            var s = await client.GetStatusAsync();
+            if (s != null) CheckInvariants(s);
+            return s;
         }
         catch
         {

--- a/Tests/ClusterTest/Program.cs
+++ b/Tests/ClusterTest/Program.cs
@@ -1,0 +1,416 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Net.Client;
+using MagicOnion.Client;
+
+namespace ClusterTest;
+
+internal static class Program
+{
+    static async Task<int> Main(string[] args)
+    {
+        if (args.Length == 0 || args[0] == "coordinator")
+        {
+            await new Coordinator().RunAsync(args.Skip(1).ToArray());
+            return 0;
+        }
+
+        if (args[0] == "node")
+        {
+            string cfgPath = args[1];
+            var cfg = JsonSerializer.Deserialize<NodeConfiguration>(await File.ReadAllTextAsync(cfgPath))
+                      ?? throw new Exception("Bad config file");
+
+            var host = new ClusterNodeHost(cfg);
+            await host.StartAsync();
+
+            // The "writer" role drives traffic when this node is the leader.
+            _ = Task.Run(async () =>
+            {
+                long counter = 0;
+                while (true)
+                {
+                    if (host.Node.Role == RocksDbSharp.RaftRole.Leader)
+                    {
+                        for (int i = 0; i < 200; i++)
+                        {
+                            string key = $"{host.Node.NodeId}_{counter++:D012}";
+                            host.Db.Put(key, $"{Stopwatch.GetTimestamp()}");
+                        }
+                    }
+                    await Task.Delay(50);
+                }
+            });
+
+            // Console reporting once per second
+            _ = Task.Run(async () =>
+            {
+                while (true)
+                {
+                    Console.WriteLine($"[{DateTimeOffset.UtcNow:HH:mm:ss.fff} {host.Node.NodeId}] " +
+                                      $"role={host.Node.Role} term={host.Node.CurrentTerm} " +
+                                      $"leader={host.Node.CurrentLeaderId} " +
+                                      $"latest={host.Db.GetLatestSequenceNumber():n0} " +
+                                      $"commit={host.Node.CommitSeq:n0} mode={host.Node.Mode} " +
+                                      $"bootSync={host.Node.BootstrapInSyncCount}");
+                    await Task.Delay(2000);
+                }
+            });
+
+            // Keep the process alive until killed.
+            await Task.Delay(-1);
+            return 0;
+        }
+
+        Console.Error.WriteLine($"Unknown mode: {args[0]}");
+        return 1;
+    }
+}
+
+internal sealed class Coordinator
+{
+    private readonly string _tempRoot;
+    private readonly string _exePath;
+    private readonly string _argsPrefix;
+    private readonly List<NodeProcess> _processes = new();
+
+    public Coordinator()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "RocksDbClusterTest_" + DateTime.UtcNow.Ticks);
+        Directory.CreateDirectory(_tempRoot);
+
+        _exePath = Process.GetCurrentProcess().MainModule?.FileName ?? "dotnet";
+        // If we are hosted by `dotnet ...ClusterTest.dll`, re-launch children with
+        // the same DLL so they reuse the compiled output rather than running
+        // `dotnet run` which would re-build for every spawn.
+        if (_exePath.EndsWith("dotnet") || _exePath.EndsWith("dotnet.exe"))
+        {
+            string? dllPath = typeof(Coordinator).Assembly.Location;
+            if (!string.IsNullOrEmpty(dllPath) && File.Exists(dllPath))
+            {
+                _argsPrefix = $"\"{dllPath}\" ";
+            }
+            else
+            {
+                _argsPrefix = "run --project Tests/ClusterTest/ClusterTest.csproj -- ";
+            }
+        }
+        else
+        {
+            _argsPrefix = "";
+        }
+    }
+
+    public async Task RunAsync(string[] args)
+    {
+        string scenario = args.Length > 0 ? args[0] : "all";
+
+        Log($"temp dir: {_tempRoot}");
+        try
+        {
+            switch (scenario)
+            {
+                case "election": await ScenarioElectionAsync(); break;
+                case "crash":    await ScenarioLeaderCrashAsync(); break;
+                case "hang":     await ScenarioLeaderHangAsync(); break;
+                case "rejoin":   await ScenarioFollowerCrashRejoinAsync(); break;
+                case "all":
+                    await ScenarioElectionAsync();
+                    await ScenarioLeaderCrashAsync();
+                    await ScenarioLeaderHangAsync();
+                    await ScenarioFollowerCrashRejoinAsync();
+                    break;
+                default:
+                    Console.Error.WriteLine($"Unknown scenario '{scenario}'. Use: election | crash | hang | rejoin | all");
+                    return;
+            }
+        }
+        finally
+        {
+            KillAll();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenarios
+    // -----------------------------------------------------------------------
+
+    private async Task ScenarioElectionAsync()
+    {
+        Log("=== scenario: bootstrap → cluster mode promotion ===");
+        var cluster = StartCluster(3, scenarioName: "election");
+
+        await WaitForClusterModeAsync(cluster, TimeSpan.FromSeconds(45));
+        Log("cluster has switched to Cluster mode");
+
+        var leader = await WaitForLeaderAsync(cluster, TimeSpan.FromSeconds(20));
+        Log($"current leader = {leader}");
+
+        KillAll();
+        await Task.Delay(500);
+    }
+
+    private async Task ScenarioLeaderCrashAsync()
+    {
+        Log("=== scenario: leader crash → re-election ===");
+        var cluster = StartCluster(3, scenarioName: "crash");
+        await WaitForClusterModeAsync(cluster, TimeSpan.FromSeconds(45));
+        var leader = await WaitForLeaderAsync(cluster, TimeSpan.FromSeconds(20));
+        Log($"initial leader = {leader}");
+
+        var leaderProc = cluster.First(c => c.Config.NodeId == leader);
+        Log($"killing leader {leader} (pid {leaderProc.Process.Id})");
+        leaderProc.Process.Kill(entireProcessTree: true);
+        await Task.Delay(500);
+
+        // remaining nodes should elect a new leader
+        var remaining = cluster.Where(c => c.Config.NodeId != leader).ToList();
+        var newLeader = await WaitForLeaderAsync(remaining, TimeSpan.FromSeconds(30), differentFrom: leader);
+        Log($"new leader = {newLeader}");
+
+        KillAll();
+        await Task.Delay(500);
+    }
+
+    private async Task ScenarioLeaderHangAsync()
+    {
+        Log("=== scenario: leader hang (SIGSTOP) → re-election → SIGCONT ===");
+        var cluster = StartCluster(3, scenarioName: "hang");
+        await WaitForClusterModeAsync(cluster, TimeSpan.FromSeconds(45));
+        var leader = await WaitForLeaderAsync(cluster, TimeSpan.FromSeconds(20));
+        Log($"initial leader = {leader}");
+
+        var leaderProc = cluster.First(c => c.Config.NodeId == leader);
+        Log($"freezing leader {leader} (pid {leaderProc.Process.Id})");
+        if (!StopProcess(leaderProc.Process))
+        {
+            Log("SIGSTOP unavailable on this OS; falling back to Kill");
+            leaderProc.Process.Kill(entireProcessTree: true);
+        }
+
+        // followers should elect a new leader once the heartbeat lapses
+        var remaining = cluster.Where(c => c.Config.NodeId != leader).ToList();
+        var newLeader = await WaitForLeaderAsync(remaining, TimeSpan.FromSeconds(30), differentFrom: leader);
+        Log($"new leader (while old is frozen) = {newLeader}");
+
+        // resume the frozen node and confirm it becomes a follower of the new leader
+        Log($"resuming {leader}");
+        ContinueProcess(leaderProc.Process);
+
+        await WaitUntilAsync(async () =>
+        {
+            var s = await TryGetStatusAsync(leaderProc.Config.Endpoint);
+            return s != null && s.LeaderId == newLeader && s.Role == "Follower";
+        }, TimeSpan.FromSeconds(20), $"resumed node {leader} accepts {newLeader} as leader");
+
+        KillAll();
+        await Task.Delay(500);
+    }
+
+    private async Task ScenarioFollowerCrashRejoinAsync()
+    {
+        Log("=== scenario: follower crash → restart → catch-up ===");
+        var cluster = StartCluster(3, scenarioName: "rejoin");
+        await WaitForClusterModeAsync(cluster, TimeSpan.FromSeconds(45));
+        var leader = await WaitForLeaderAsync(cluster, TimeSpan.FromSeconds(20));
+
+        var follower = cluster.First(c => c.Config.NodeId != leader && !c.Config.BootstrapPrimary);
+        Log($"killing follower {follower.Config.NodeId} (pid {follower.Process.Id})");
+        follower.Process.Kill(entireProcessTree: true);
+        await Task.Delay(1500);
+
+        Log($"restarting follower {follower.Config.NodeId}");
+        var restarted = StartNodeProcess(follower.Config);
+        cluster.Add(restarted);
+
+        await WaitUntilAsync(async () =>
+        {
+            var s = await TryGetStatusAsync(follower.Config.Endpoint);
+            if (s == null) return false;
+            var leaderStatus = await TryGetStatusAsync(cluster.First(c => c.Config.NodeId == leader).Config.Endpoint);
+            if (leaderStatus == null) return false;
+            return s.LatestSeq + 5000 >= leaderStatus.LatestSeq;
+        }, TimeSpan.FromSeconds(60), $"follower {follower.Config.NodeId} caught back up");
+
+        KillAll();
+        await Task.Delay(500);
+    }
+
+    // -----------------------------------------------------------------------
+    // Cluster bootstrap helpers
+    // -----------------------------------------------------------------------
+
+    private List<NodeProcess> StartCluster(int nodeCount, string scenarioName)
+    {
+        int basePort = 51000 + (Math.Abs(scenarioName.GetHashCode()) % 50) * 10;
+        var members = new List<MemberConfig>();
+        for (int i = 0; i < nodeCount; i++)
+        {
+            members.Add(new MemberConfig
+            {
+                NodeId = $"node{i + 1}",
+                Endpoint = $"http://localhost:{basePort + i}",
+                IsBootstrapPrimary = i == 0,
+            });
+        }
+
+        var result = new List<NodeProcess>();
+        for (int i = 0; i < nodeCount; i++)
+        {
+            var cfg = new NodeConfiguration
+            {
+                NodeId = members[i].NodeId,
+                Endpoint = members[i].Endpoint,
+                Port = basePort + i,
+                DbPath = Path.Combine(_tempRoot, scenarioName, $"node{i + 1}"),
+                BootstrapPrimary = members[i].IsBootstrapPrimary,
+                AllMembers = members,
+                ElectionTimeoutMinMs = 1500,
+                ElectionTimeoutMaxMs = 3000,
+                HeartbeatIntervalMs = 250,
+                BootstrapInSyncLagThreshold = 50_000,
+            };
+            // give the primary a head start so it can serve initial snapshots
+            if (i > 0) Thread.Sleep(800);
+            result.Add(StartNodeProcess(cfg));
+        }
+        return result;
+    }
+
+    private NodeProcess StartNodeProcess(NodeConfiguration cfg)
+    {
+        Directory.CreateDirectory(cfg.DbPath);
+        string cfgPath = Path.Combine(cfg.DbPath, "node.json");
+        File.WriteAllText(cfgPath, JsonSerializer.Serialize(cfg));
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = _exePath,
+            Arguments = $"{_argsPrefix}node \"{cfgPath}\"",
+            UseShellExecute = false,
+            CreateNoWindow = false,
+        };
+        var proc = Process.Start(psi)!;
+        var np = new NodeProcess(cfg, proc);
+        _processes.Add(np);
+        Log($"started {cfg.NodeId} pid={proc.Id} on {cfg.Endpoint} (bootstrap={cfg.BootstrapPrimary})");
+        return np;
+    }
+
+    private void KillAll()
+    {
+        foreach (var p in _processes)
+        {
+            try { if (!p.Process.HasExited) p.Process.Kill(entireProcessTree: true); } catch { }
+        }
+        _processes.Clear();
+    }
+
+    // -----------------------------------------------------------------------
+    // Wait helpers
+    // -----------------------------------------------------------------------
+
+    private async Task WaitForClusterModeAsync(IEnumerable<NodeProcess> cluster, TimeSpan timeout)
+    {
+        await WaitUntilAsync(async () =>
+        {
+            int count = 0;
+            int inMode = 0;
+            foreach (var c in cluster)
+            {
+                var s = await TryGetStatusAsync(c.Config.Endpoint);
+                if (s == null) continue;
+                count++;
+                if (s.Mode == (int)RocksDbSharp.ClusterMode.Cluster) inMode++;
+            }
+            return count > 0 && inMode == count;
+        }, timeout, "all nodes are in Cluster mode");
+    }
+
+    private async Task<string> WaitForLeaderAsync(IEnumerable<NodeProcess> cluster, TimeSpan timeout, string? differentFrom = null)
+    {
+        string? lastLeader = null;
+        await WaitUntilAsync(async () =>
+        {
+            var leaders = new HashSet<string>();
+            foreach (var c in cluster)
+            {
+                var s = await TryGetStatusAsync(c.Config.Endpoint);
+                if (s == null) continue;
+                if (s.Role == "Leader") leaders.Add(s.NodeId);
+            }
+            if (leaders.Count == 1)
+            {
+                var l = leaders.First();
+                if (differentFrom != null && l == differentFrom) return false;
+                lastLeader = l;
+                return true;
+            }
+            return false;
+        }, timeout, differentFrom == null ? "exactly one leader" : $"a leader other than {differentFrom}");
+        return lastLeader!;
+    }
+
+    private static async Task WaitUntilAsync(Func<Task<bool>> check, TimeSpan timeout, string label)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed < timeout)
+        {
+            try { if (await check()) return; } catch { }
+            await Task.Delay(500);
+        }
+        throw new TimeoutException($"Timeout waiting for: {label}");
+    }
+
+    private static async Task<NodeStatus?> TryGetStatusAsync(string endpoint)
+    {
+        try
+        {
+            using var ch = GrpcChannel.ForAddress(endpoint);
+            var client = MagicOnionClient.Create<IClusterService>(ch);
+            return await client.GetStatusAsync();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Unix signal helpers (no-ops on Windows; tests fall back to kill)
+    // -----------------------------------------------------------------------
+
+    private static bool StopProcess(Process p) => SendUnixSignal(p, 19); // SIGSTOP
+    private static bool ContinueProcess(Process p) => SendUnixSignal(p, 18); // SIGCONT
+
+    private static bool SendUnixSignal(Process p, int signal)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return false;
+        try
+        {
+            int rc = NativeKill(p.Id, signal);
+            return rc == 0;
+        }
+        catch { return false; }
+    }
+
+    [DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+    private static extern int NativeKill(int pid, int sig);
+
+    private static void Log(string msg) =>
+        Console.WriteLine($"[{DateTimeOffset.UtcNow:HH:mm:ss.fff} coordinator] {msg}");
+
+    private sealed class NodeProcess
+    {
+        public NodeConfiguration Config { get; }
+        public Process Process { get; }
+        public NodeProcess(NodeConfiguration cfg, Process p) { Config = cfg; Process = p; }
+    }
+}

--- a/csharp/src/Cluster/ClusterEvents.cs
+++ b/csharp/src/Cluster/ClusterEvents.cs
@@ -1,0 +1,25 @@
+#if NET5_0_OR_GREATER
+using System;
+
+namespace RocksDbSharp;
+
+public sealed class LeaderChangedEventArgs : EventArgs
+{
+    public string? LeaderId { get; }
+    public long Term { get; }
+    public LeaderChangedEventArgs(string? leaderId, long term) { LeaderId = leaderId; Term = term; }
+}
+
+public sealed class ModeChangedEventArgs : EventArgs
+{
+    public ClusterMode Mode { get; }
+    public ModeChangedEventArgs(ClusterMode mode) { Mode = mode; }
+}
+
+public sealed class RoleChangedEventArgs : EventArgs
+{
+    public RaftRole Role { get; }
+    public long Term { get; }
+    public RoleChangedEventArgs(RaftRole role, long term) { Role = role; Term = term; }
+}
+#endif

--- a/csharp/src/Cluster/ClusterMember.cs
+++ b/csharp/src/Cluster/ClusterMember.cs
@@ -1,0 +1,24 @@
+#if NET5_0_OR_GREATER
+using System;
+
+namespace RocksDbSharp;
+
+public sealed class ClusterMember : IEquatable<ClusterMember>
+{
+    public string NodeId { get; }
+    public string Endpoint { get; }
+
+    public ClusterMember(string nodeId, string endpoint)
+    {
+        if (string.IsNullOrWhiteSpace(nodeId)) throw new ArgumentException("NodeId is required", nameof(nodeId));
+        if (string.IsNullOrWhiteSpace(endpoint)) throw new ArgumentException("Endpoint is required", nameof(endpoint));
+        NodeId = nodeId;
+        Endpoint = endpoint;
+    }
+
+    public bool Equals(ClusterMember? other) => other != null && other.NodeId == NodeId;
+    public override bool Equals(object? obj) => obj is ClusterMember m && Equals(m);
+    public override int GetHashCode() => NodeId.GetHashCode(StringComparison.Ordinal);
+    public override string ToString() => $"{NodeId}@{Endpoint}";
+}
+#endif

--- a/csharp/src/Cluster/ClusterMode.cs
+++ b/csharp/src/Cluster/ClusterMode.cs
@@ -1,0 +1,19 @@
+#if NET5_0_OR_GREATER
+namespace RocksDbSharp;
+
+/// <summary>
+/// Two phases of the clustering database life cycle.
+///
+/// Bootstrap: one designated primary accepts writes while peers catch up via the
+/// existing snapshot + WAL replication path. No election is performed in this
+/// phase.
+///
+/// Cluster: full Raft is in effect. The leader is elected by quorum and any
+/// member may be promoted after a leader failure.
+/// </summary>
+public enum ClusterMode
+{
+    Bootstrap = 0,
+    Cluster = 1,
+}
+#endif

--- a/csharp/src/Cluster/ElectionTimer.cs
+++ b/csharp/src/Cluster/ElectionTimer.cs
@@ -1,0 +1,83 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Threading;
+
+namespace RocksDbSharp;
+
+/// <summary>
+/// Randomized election timer used by Raft followers and candidates.
+///
+/// The timer is reset by leader heartbeats and by granted votes. When it
+/// elapses, <see cref="OnTimeout"/> fires - typically transitioning the node
+/// to Candidate and starting a new election.
+/// </summary>
+public sealed class ElectionTimer : IDisposable
+{
+    private readonly Action _onTimeout;
+    private readonly int _minMs;
+    private readonly int _maxMs;
+    private readonly Random _rng;
+    private readonly object _gate = new();
+
+    private Timer? _timer;
+    private bool _disposed;
+    private long _lastResetTicks;
+
+    public ElectionTimer(int minMs, int maxMs, Action onTimeout)
+    {
+        _minMs = minMs;
+        _maxMs = maxMs;
+        _onTimeout = onTimeout ?? throw new ArgumentNullException(nameof(onTimeout));
+        _rng = new Random(Environment.TickCount ^ Thread.CurrentThread.ManagedThreadId);
+    }
+
+    public DateTime LastResetUtc => new DateTime(Interlocked.Read(ref _lastResetTicks), DateTimeKind.Utc);
+
+    public void Start()
+    {
+        Reset();
+    }
+
+    public void Reset()
+    {
+        lock (_gate)
+        {
+            if (_disposed) return;
+            int next = _rng.Next(_minMs, _maxMs + 1);
+            Interlocked.Exchange(ref _lastResetTicks, DateTime.UtcNow.Ticks);
+            if (_timer == null)
+            {
+                _timer = new Timer(_ => SafeTimeout(), null, next, Timeout.Infinite);
+            }
+            else
+            {
+                _timer.Change(next, Timeout.Infinite);
+            }
+        }
+    }
+
+    public void Pause()
+    {
+        lock (_gate)
+        {
+            _timer?.Change(Timeout.Infinite, Timeout.Infinite);
+        }
+    }
+
+    private void SafeTimeout()
+    {
+        try { _onTimeout(); }
+        catch { /* swallowed; the caller logs */ }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            _disposed = true;
+            _timer?.Dispose();
+            _timer = null;
+        }
+    }
+}
+#endif

--- a/csharp/src/Cluster/PeerState.cs
+++ b/csharp/src/Cluster/PeerState.cs
@@ -36,8 +36,10 @@ public sealed class PeerState
 
     public void OnAppendSucceeded(ulong matchSeq)
     {
-        Interlocked.Exchange(ref _matchSeq, (long)matchSeq);
-        Interlocked.Exchange(ref _nextSeq, (long)matchSeq + 1);
+        // Progress reports race with heartbeat acknowledgements; whichever
+        // confirmed less must never roll an already-confirmed prefix back.
+        InterlockedMax(ref _matchSeq, (long)matchSeq);
+        InterlockedMax(ref _nextSeq, (long)matchSeq + 1);
         Interlocked.Exchange(ref _lastSuccessfulContactTicks, DateTime.UtcNow.Ticks);
         Volatile.Write(ref _reachable, 1);
     }
@@ -56,6 +58,28 @@ public sealed class PeerState
     public void RewindOnConflict(ulong newNextSeq)
     {
         Interlocked.Exchange(ref _nextSeq, (long)newNextSeq);
+    }
+
+    /// <summary>
+    /// Called when this node wins an election: matchSeq goes back to 0 (we
+    /// know nothing about the peer's log in the new term yet) and nextSeq is
+    /// positioned at the end of our own log (§5.3).
+    /// </summary>
+    public void ResetForNewTerm(ulong nextSeq)
+    {
+        Interlocked.Exchange(ref _matchSeq, 0);
+        Interlocked.Exchange(ref _nextSeq, (long)nextSeq);
+    }
+
+    private static void InterlockedMax(ref long location, long value)
+    {
+        long current = Interlocked.Read(ref location);
+        while (value > current)
+        {
+            long prev = Interlocked.CompareExchange(ref location, value, current);
+            if (prev == current) break;
+            current = prev;
+        }
     }
 }
 #endif

--- a/csharp/src/Cluster/PeerState.cs
+++ b/csharp/src/Cluster/PeerState.cs
@@ -1,0 +1,61 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Threading;
+
+namespace RocksDbSharp;
+
+/// <summary>
+/// Per-peer tracking maintained by the leader.
+///
+/// nextIndex / matchIndex mirror the variables from Raft §5.3 but, because our
+/// "log" is the RocksDB WAL keyed by sequence number, we name them with the
+/// "Seq" suffix.
+/// </summary>
+public sealed class PeerState
+{
+    public ClusterMember Member { get; }
+
+    private long _matchSeq;
+    private long _nextSeq;
+    private long _lastSuccessfulContactTicks;
+    private int _reachable; // 1/0
+
+    public PeerState(ClusterMember member, ulong initialNextSeq)
+    {
+        Member = member;
+        _matchSeq = 0;
+        _nextSeq = (long)initialNextSeq;
+        _reachable = 0;
+    }
+
+    public ulong MatchSeq => (ulong)Interlocked.Read(ref _matchSeq);
+    public ulong NextSeq => (ulong)Interlocked.Read(ref _nextSeq);
+    public bool IsReachable => Volatile.Read(ref _reachable) == 1;
+    public DateTime LastSuccessfulContactUtc =>
+        new DateTime(Interlocked.Read(ref _lastSuccessfulContactTicks), DateTimeKind.Utc);
+
+    public void OnAppendSucceeded(ulong matchSeq)
+    {
+        Interlocked.Exchange(ref _matchSeq, (long)matchSeq);
+        Interlocked.Exchange(ref _nextSeq, (long)matchSeq + 1);
+        Interlocked.Exchange(ref _lastSuccessfulContactTicks, DateTime.UtcNow.Ticks);
+        Volatile.Write(ref _reachable, 1);
+    }
+
+    public void OnAppendFailed()
+    {
+        Volatile.Write(ref _reachable, 0);
+    }
+
+    public void OnHeartbeatAcknowledged()
+    {
+        Interlocked.Exchange(ref _lastSuccessfulContactTicks, DateTime.UtcNow.Ticks);
+        Volatile.Write(ref _reachable, 1);
+    }
+
+    public void RewindOnConflict(ulong newNextSeq)
+    {
+        Interlocked.Exchange(ref _nextSeq, (long)newNextSeq);
+    }
+}
+#endif

--- a/csharp/src/Cluster/README.md
+++ b/csharp/src/Cluster/README.md
@@ -220,12 +220,27 @@ The resync itself (`ClusterNodeHost.PerformResyncAsync`):
   votes (a voter with a half-rebuilt log could help elect a candidate that
   lacks committed entries) and answer heartbeats with `"resyncing"` without
   touching the database;
-- the local DB is disposed and the data directory wiped **except** the
-  `raft/` state directory (term and vote must survive - they are promises);
-- a checkpoint is pulled from the current leader via the chunked
-  `SyncInitialStateAsync` stream, followed by the leader's term map
-  (`GetRaftTermsAsync`) - the restored log is byte-for-byte the leader's log,
-  so the leader's term map is its correct description;
+- the local DB is disposed and a **per-file delta transfer** runs against the
+  leader's checkpoint (`ReplicationDelta` in `csharp/src/Replication`, so the
+  plain replication path can use the same mechanism):
+  - the node offers an inventory of its local immutable files
+    (`.sst` / `.blob`) with sizes and SHA-256 hashes;
+  - the leader answers with a plan: files the node may **reuse** (present
+    byte-identically in the checkpoint) and then streams - chunked, in full -
+    only the files that are **new or changed**. Granularity is whole files;
+    there is no content-level patching. Name + size alone would not be safe:
+    once a replica stops sharing a lineage with the leader it allocates SST
+    file numbers independently, so equal names do not imply equal content;
+  - before anything lands, the node deletes its journal/WAL directory and
+    every local file the plan didn't confirm - stale or divergent SSTs, the
+    old `MANIFEST`/`CURRENT` - keeping only the `raft/` state directory
+    (term and vote must survive - they are promises);
+  - `CURRENT` is transferred last, so a node that dies mid-restore is left
+    without a valid DB marker and re-pulls cleanly on restart (reusing the
+    files it already received);
+- the leader's term map follows (`GetRaftTermsAsync`) - the restored log is
+  byte-for-byte the leader's log, so the leader's term map is its correct
+  description;
 - `Node.CompleteResync(newDb)` swaps the database in and re-arms the
   election timer, and the WAL stream re-attaches (passing the attach-time
   check this time).

--- a/csharp/src/Cluster/README.md
+++ b/csharp/src/Cluster/README.md
@@ -1,0 +1,379 @@
+# RocksDbSharp Clustering
+
+This folder contains a transport-agnostic Raft implementation that turns the
+existing single-primary/single-replica WAL streaming into a fault-tolerant,
+multi-node clustering database. The Raft layer reuses the snapshot + WAL
+replication primitives unchanged - this code only adds:
+
+- term-and-vote bookkeeping,
+- leader election,
+- heartbeat-driven liveness detection,
+- quorum-based commit advancement,
+- a "bootstrap" initialization phase that lets one primary keep serving writes
+  until the cluster has caught up enough to switch on full Raft.
+
+The MagicOnion service that wires these classes onto gRPC lives in
+`Tests/ClusterTest/`. Nothing in this folder depends on gRPC, MagicOnion, or
+ASP.NET, so the same library can be embedded in any transport.
+
+---
+
+## File map
+
+| File | Purpose |
+|------|---------|
+| `RaftRole.cs` | `Follower / Candidate / Leader` enum. |
+| `ClusterMode.cs` | `Bootstrap / Cluster` enum (life-cycle phase). |
+| `ClusterMember.cs` | `(NodeId, Endpoint)` value object for cluster peers. |
+| `RaftConfig.cs` | Per-node configuration: peers, election + heartbeat timings, bootstrap quorum and in-sync threshold. |
+| `RaftPersistentState.cs` | Crash-safe `(currentTerm, votedFor, mode)` plus the term-range log; written via atomic temp-file rename. |
+| `RaftLogTerms.cs` | Sparse `(startSeq -> term)` map. Binary-searchable. Lets a node answer "what was the term of WAL entry N?". |
+| `PeerState.cs` | Per-follower `matchSeq / nextSeq / reachable` tracking maintained by the leader. |
+| `ElectionTimer.cs` | Randomized election timeout in `[MinMs, MaxMs]`, reset by heartbeats. |
+| `RaftClusterNode.cs` | The orchestrator. Owns role transitions, election state, leader heartbeat fan-out and commit advancement. Talks to peers via `IPeerTransport`. |
+| `ClusterEvents.cs` | `LeaderChanged / RoleChanged / ModeChanged` event args. |
+
+---
+
+## Why "RocksDB seqNo is the Raft log index"
+
+Classical Raft has its own append-only log. We do not - the RocksDB WAL is
+already an append-only log of `(seqNo, batchBytes)` entries with all the
+durability guarantees we need. So:
+
+- **Raft log index** = RocksDB sequence number (`db.GetLatestSequenceNumber()`).
+- **Log replication** = the existing `ReplicationSource.GetPooledWalUpdates(seq)`
+  streamed over gRPC.
+- **Catch-up from far behind** = the existing `ReplicationSource.GetInitialState`
+  checkpoint transfer (`SyncInitialStateAsync` on the wire).
+
+What Raft additionally needs is a **term** attached to every log entry. Storing
+a term inside every WriteBatch would require modifying RocksDB. Instead we
+keep a tiny **side-log of term ranges** in `raft.terms`: each row is
+`(startSeq, term)` and any entry's term is the term of the largest
+`startSeq <= seqNo`. The leader appends a new row on every leadership win, and
+followers append a new row whenever they observe a batch tagged with an unseen
+term in the WAL stream.
+
+That side-log plus `(currentTerm, votedFor, mode)` is the only Raft state
+written to disk. Everything else is derivable.
+
+---
+
+## Life cycle
+
+### 1. Bootstrap (initialization)
+
+The cluster starts with **one** designated primary
+(`RaftConfig.BootstrapPrimary = true`). On startup:
+
+- The primary opens its RocksDB normally and is **forced into the Leader role
+  without holding an election**. It writes `currentTerm = 1, votedFor = self`
+  to disk and records the term-range row `(latestSeq + 1 -> 1)`.
+- Every other node, on first boot, finds an empty data directory, looks up the
+  bootstrap primary from its config, and pulls a full checkpoint via
+  `SyncInitialStateAsync`. Then it opens its local DB and starts the
+  follower-stream (`SyncUpdatesAsync`) from `latestSeq + 1`.
+- Followers receive WAL batches tagged with the leader's current term and
+  leader id. As they ingest they:
+  - call `Node.HandleObservedLeader(leaderId, term)` to update their view of
+    who the leader is and what term they're in,
+  - append a new term-range row whenever the batch's term differs from the
+    last one they recorded.
+- Periodically the follower stream calls
+  `ReportLastSyncSequenceNumber(nodeId, latestSeq)` so the leader can update
+  the follower's `matchSeq`.
+- While `Mode == Bootstrap`, **no election is allowed**. `HandleRequestVote`
+  refuses every vote and the follower's election timer resets itself instead
+  of starting a candidate run. This prevents split-brain before the cluster
+  has any replicated data to vote on.
+
+The primary keeps accepting writes the entire time. Bootstrap is what lets
+the cluster be useful before it has converged.
+
+### 2. Promotion to Cluster mode
+
+After each successful `ReportLastSyncSequenceNumber` the leader runs
+`MaybePromoteToCluster()`:
+
+- Count followers whose `matchSeq + lagThreshold >= latestSeq` (i.e. within
+  `BootstrapInSyncLagThreshold` WAL records of the leader). Add 1 for self.
+- If that count reaches `BootstrapPromotionQuorum`
+  (defaults to a strict majority of `peers + 1`), the leader writes
+  `mode = Cluster` to its own `raft.state` and raises `ModeChanged`.
+- The new mode is broadcast by piggybacking on the next heartbeat
+  (`HeartbeatPayload.LeaderMode`). Each follower's `HandleAppendEntries`
+  promotes itself to Cluster mode when it sees a heartbeat with
+  `LeaderMode == Cluster`, persists that flag and raises its own
+  `ModeChanged`.
+
+Once a node has flipped to Cluster mode, it never goes back. The transition
+is one-way.
+
+### 3. Steady-state Cluster mode
+
+In Cluster mode every node enforces full Raft:
+
+- **Leader** sends a heartbeat to each peer every `HeartbeatIntervalMs` ms
+  (default 250-300ms). The heartbeat carries
+  `(term, leaderId, prevLogSeq, prevLogTerm, leaderCommit, leaderMode)` -
+  no batch data; data flows on the long-lived `SyncUpdatesAsync` stream.
+- **Follower** resets its election timer on every accepted heartbeat. If the
+  randomized timer (default `[1500, 3000]` ms) elapses without a heartbeat, it
+  becomes a candidate.
+- **Commit advancement**: the leader keeps a `matchSeq` per peer; on each
+  reported progress it sorts the values plus its own `latestSeq` descending,
+  picks the value at quorum index (`majority-1`), and that becomes the new
+  `commitSeq`. Followers receive `leaderCommit` on the next heartbeat and
+  advance theirs accordingly.
+
+---
+
+## Election protocol
+
+The election logic lives in `RaftClusterNode.OnElectionTimeout` /
+`RunElectionAsync`. It follows §5.2 of the Raft paper with the obvious
+mapping from "log index" to "WAL seqNo".
+
+1. Election timer fires on a Follower (or a Candidate whose previous election
+   was inconclusive).
+2. The node transitions to `Candidate`, bumps `currentTerm`, votes for self,
+   and resets the election timer with a new random value.
+3. It sends `RequestVote(term, candidateId, lastLogSeq, lastLogTerm)` to all
+   peers in parallel.
+4. Each peer's `HandleRequestVote` grants the vote iff **all** of these hold:
+   - the request's `term >= currentTerm` (the receiver may step down and bump
+     its term first);
+   - `Mode == Cluster` (we never vote during Bootstrap);
+   - `votedFor` is null or already equal to `candidateId` for this term;
+   - the candidate's `(lastLogTerm, lastLogSeq)` is at least as up-to-date as
+     ours (lexicographic compare): a candidate with a stale log cannot win.
+5. The candidate counts grants. As soon as it has `Quorum` votes
+   (including its own), it calls `BecomeLeader()`:
+   - record a new term-range row at `latestSeq + 1`,
+   - reset every peer's `nextSeq` to `latestSeq + 1`,
+   - pause the election timer,
+   - start the heartbeat loop, which immediately notifies all peers of the new
+     term and leader id.
+6. If the candidate sees any response with a higher term, it steps down to
+   Follower for that term.
+7. If the election timer fires again before a quorum, the candidate starts a
+   **new** election in the next term. The randomized timeout makes a split
+   vote unlikely to repeat.
+
+Persistence guarantees during elections:
+
+- `currentTerm` is fsync'd (atomic temp-file rename) **before** any
+  `RequestVote` is sent or any vote is granted.
+- `votedFor` is fsync'd before the granting reply is returned.
+- The new term-range row is fsync'd inside `BecomeLeader` before any
+  heartbeat with the new term goes out.
+
+This is what makes the algorithm safe across crashes - a candidate that wins
+then dies cannot come back as a follower of a lower term and accept
+conflicting log entries.
+
+---
+
+## Failure modes
+
+### Leader process crash (kill -9)
+
+The leader simply disappears. From every follower's perspective heartbeats
+stop arriving and `SyncUpdatesAsync` returns an end-of-stream / Unavailable.
+The follower stream task logs the error and starts retrying every second; in
+parallel the election timer keeps running and fires within
+`[ElectionTimeoutMinMs, ElectionTimeoutMaxMs]` of the last heartbeat. The
+first follower to time out wins the election (provided its log is at least as
+up-to-date as a quorum's), promotes itself, and starts sending heartbeats.
+
+Empirically the path takes ~2-3 seconds: ~election-timeout to detect, plus
+the round-trip of the first heartbeat-cycle from the new leader.
+
+When the dead leader is restarted, its data directory is intact. It reads
+back `(currentTerm = T, votedFor, mode = Cluster, terms log)` from disk. The
+first heartbeat it receives from the new leader carries `term > T`, so
+`HandleAppendEntries` bumps its term, calls `BecomeFollower(newLeader)`, and
+the WAL stream picks up where it left off.
+
+### Leader hang (SIGSTOP / GC pause / blocked thread)
+
+This is the hardest failure to distinguish from a partition - the process
+is alive but not responding. Detection is purely timeout-based:
+
+- The hung leader stops sending heartbeats.
+- Followers time out and run an election. The hung leader is unreachable so
+  it does not get to vote, but its absence doesn't matter as long as a
+  quorum of the other nodes is reachable.
+- A new leader is elected at a higher term.
+
+When the hung process resumes (SIGCONT, GC finishes, etc.):
+
+- Its own heartbeat fan-out will fail or return responses carrying the higher
+  term. Either condition triggers `BecomeFollower(null)` and persists the new
+  term.
+- The next heartbeat from the new leader confirms it and re-attaches the
+  follower stream.
+
+There is a small write-visibility window: between the moment the leader
+freezes and the moment it discovers the higher term, it would happily accept
+client writes (it still believes it is leader). Those writes never reach a
+quorum so they never commit; when the node steps down, RocksDB's WAL still
+contains them. They will be **overwritten on resync if the new leader's log
+diverges**: the follower's `HandleAppendEntries` returns
+`Success = false, Reason = "term-mismatch"` and the host code re-snapshots
+from the leader via `SyncInitialStateAsync`. From a client's point of view
+the uncommitted writes simply never happened - they were never acknowledged.
+
+This is the standard Raft trade-off: only **committed** writes are durable.
+Uncommitted writes on a deposed leader are silently dropped.
+
+### Follower process crash
+
+The leader's heartbeat to that peer fails; `peer.OnAppendFailed()` flips
+`reachable = false`. Commit advancement is not affected as long as a quorum
+of the remaining followers acknowledge.
+
+On restart the follower:
+
+- reads back its persistent Raft state and its RocksDB WAL,
+- starts as Follower (it is not the bootstrap primary on restart - the
+  bootstrap path is gated on an empty data directory),
+- the host code reconnects `SyncUpdatesAsync(startSeq = latestSeq + 1)` to the
+  current leader,
+- receives heartbeats and resumes log replication from where it left off.
+
+If the follower has been down long enough that the leader has truncated WAL
+files past its `latestSeq`, the next batch will produce a sequence-number gap
+when the consumer tries to ingest, and the host falls back to a full
+`SyncInitialStateAsync` snapshot (this is exactly the same recovery path
+that the existing single-replica setup uses).
+
+### Network partition
+
+A partition is the same as "leader hang" from each side's perspective: each
+side sees timeouts on the other side.
+
+- The side **containing a majority** continues without disruption. If it
+  already contains the leader, nothing changes - heartbeats keep flowing
+  inside the majority partition. If it doesn't, the followers time out,
+  elect a new leader at a higher term, and keep going.
+- The side **without a majority** cannot elect anyone, because `Quorum`
+  requires `(N/2)+1` votes. The minority's old-leader (if any) keeps
+  accepting writes locally but those writes will never reach commit -
+  `TryAdvanceCommit` sorts `matchSeq` values and picks the quorum-th entry,
+  and on the minority side there isn't one.
+- When the partition heals, the side that fell behind discovers the higher
+  term via heartbeats, steps down, and re-syncs - exactly like the "leader
+  hang resumes" scenario above. Any non-committed writes that the minority
+  leader accepted are dropped during the term-mismatch resync.
+
+This is the safety guarantee that makes Raft non-split-brain: at most one
+side of a partition can ever achieve quorum, so at most one side can produce
+new committed writes.
+
+### Simultaneous failures
+
+The cluster tolerates `floor((N-1)/2)` simultaneous failures. With the
+default 3-node setup, that's one failure (any node, any reason). Lose two
+out of three and the survivor cannot make progress until at least one peer
+comes back.
+
+### Disk corruption / state file truncation
+
+`RaftPersistentState.Persist` writes to `raft.state.tmp` then `File.Move`'s
+it over `raft.state` (and analogously for `raft.terms`). A crash mid-write
+leaves the old file intact, so on recovery we always read a coherent
+`(term, vote, mode)` tuple. If both files are physically corrupt (e.g.
+hardware failure), `Load` falls back to `(term = 0, vote = null, mode = 0)`;
+the node will then re-snapshot from the current leader.
+
+---
+
+## What this implementation does NOT do
+
+To keep the scope tight, a few standard Raft extensions are deliberately out
+of scope:
+
+- **Pre-vote** (§9.6). A partitioned follower that rejoins will bump its term
+  and trigger one election round before stabilizing. Pre-vote would avoid
+  that small disturbance but isn't required for safety.
+- **Dynamic membership changes** (§6 of the dissertation). The peer list is
+  static for a process lifetime. Adding/removing nodes requires a config
+  update and a restart.
+- **Log compaction inside Raft** (§7). We piggyback on RocksDB's own
+  compaction - the existing replication code already prunes WAL files once
+  every follower has acknowledged past them, via
+  `RocksDbWalInspector.GetFirstSequenceNumbers`.
+- **Linearizable reads from followers**. Reads currently only have leader
+  linearizability (clients should query the leader). Adding ReadIndex would
+  let followers serve linearizable reads without a round-trip.
+- **Batched / pipelined AppendEntries**. Heartbeats are sent one-per-peer
+  every `HeartbeatIntervalMs`; the data plane is the long-lived
+  `SyncUpdatesAsync` stream, which already does pipelining via gRPC.
+
+---
+
+## Configuration cheatsheet
+
+```csharp
+new RaftConfig(
+    nodeId: "node1",
+    endpoint: "http://localhost:51000",
+    peers: new[]
+    {
+        new ClusterMember("node2", "http://localhost:51001"),
+        new ClusterMember("node3", "http://localhost:51002"),
+    },
+    bootstrapPrimary: true,           // exactly one node sets this to true
+    electionTimeoutMinMs: 1500,       // randomized in [Min, Max]
+    electionTimeoutMaxMs: 3000,
+    heartbeatIntervalMs: 250,         // must be << ElectionTimeoutMinMs
+    bootstrapInSyncLagThreshold: 50_000,
+    bootstrapPromotionQuorum: 2);     // default: majority of peers + self
+```
+
+Tuning notes:
+
+- `HeartbeatIntervalMs` should be at most `ElectionTimeoutMinMs / 3` to leave
+  headroom for transient delays.
+- `BootstrapInSyncLagThreshold` is in WAL records, not bytes. With ~10k
+  records/sec write rate, `50_000` is ~5 seconds behind.
+- `Quorum` is always `(peers+1)/2 + 1` and is computed from the peer list.
+
+---
+
+## End-to-end flow
+
+```
++--------+          snapshot           +----------+
+| primary| ----------------------------> follower |
+| (boot) |                              | (init)   |
++--------+                              +----------+
+     |                                       |
+     |  SyncUpdatesAsync (WAL stream)        |
+     |-------------------------------------->|
+     |                                       |
+     |    ReportLastSyncSequenceNumber       |
+     |<--------------------------------------|
+     |  (matchSeq advances, bootSync count   |
+     |   updates, promotion check fires)     |
+     |                                       |
+     +--- ModeChanged: Cluster --------------+
+     |                                       |
+     |   periodic HeartbeatAsync ------>     |
+     |   (term, leaderCommit, leaderMode)    |
+     |                                       |
+     +-- on leader failure -----------------+
+                                              |
+                                       election timer fires
+                                              |
+                                       RequestVoteAsync to peers
+                                              |
+                                       quorum reached -> BecomeLeader
+                                              |
+                                       new heartbeat: term++
+```
+
+See `Tests/ClusterTest/Program.cs` for a working coordinator that drives the
+four canonical scenarios end-to-end: `election`, `crash`, `hang`, `rejoin`.

--- a/csharp/src/Cluster/README.md
+++ b/csharp/src/Cluster/README.md
@@ -223,14 +223,18 @@ The resync itself (`ClusterNodeHost.PerformResyncAsync`):
 - the local DB is disposed and a **per-file delta transfer** runs against the
   leader's checkpoint (`ReplicationDelta` in `csharp/src/Replication`, so the
   plain replication path can use the same mechanism):
-  - the node offers an inventory of its local immutable files
-    (`.sst` / `.blob`) with sizes and SHA-256 hashes;
-  - the leader answers with a plan: files the node may **reuse** (present
-    byte-identically in the checkpoint) and then streams - chunked, in full -
-    only the files that are **new or changed**. Granularity is whole files;
-    there is no content-level patching. Name + size alone would not be safe:
-    once a replica stops sharing a lineage with the leader it allocates SST
-    file numbers independently, so equal names do not imply equal content;
+  - the node scans its local immutable files (`.sst` / `.blob`) by name and
+    size only, then asks the leader for content hashes via
+    `GetFileHashesAsync`. The leader hashes only the files it also holds at
+    that exact name + size, and the node hashes only its copies of those
+    candidates - files that cannot match are never hashed on either side;
+  - the node sends the verified files as its inventory; the leader answers
+    with a plan: verified files are **reused**, and it streams - chunked, in
+    full - only the files that are **new or changed**. Granularity is whole
+    files; there is no content-level patching. The hash exchange matters
+    because name + size alone would not be safe: once a replica stops
+    sharing a lineage with the leader it allocates SST file numbers
+    independently, so equal names do not imply equal content;
   - before anything lands, the node deletes its journal/WAL directory and
     every local file the plan didn't confirm - stale or divergent SSTs, the
     old `MANIFEST`/`CURRENT` - keeping only the `raft/` state directory

--- a/csharp/src/Cluster/README.md
+++ b/csharp/src/Cluster/README.md
@@ -224,10 +224,18 @@ The resync itself (`ClusterNodeHost.PerformResyncAsync`):
   leader's checkpoint (`ReplicationDelta` in `csharp/src/Replication`, so the
   plain replication path can use the same mechanism):
   - the node scans its local immutable files (`.sst` / `.blob`) by name and
-    size only, then asks the leader for content hashes via
-    `GetFileHashesAsync`. The leader hashes only the files it also holds at
-    that exact name + size, and the node hashes only its copies of those
-    candidates - files that cannot match are never hashed on either side;
+    size only, then asks the leader for identity signatures via
+    `GetFileHashesAsync`. The leader signs only the files it also holds at
+    that exact name + size, and the node signs only its copies of those
+    candidates - files that cannot match are never read on either side.
+    The signature hashes the file length plus the **last 1 MiB** rather than
+    the whole file: an SST's tail contains its footer, index and properties
+    block, which embeds RocksDB's own identity material (creating-DB UUID,
+    DB session identity, original file number, creation times), so distinct
+    creation events always differ there while byte-copies match. Hashing the
+    *head* would not be safe - a replica's locally flushed SST can carry a
+    byte-identical data prefix and differ only near the end. Per-block CRCs
+    inside the SST still guard reused files against corruption at read time;
   - the node sends the verified files as its inventory; the leader answers
     with a plan: verified files are **reused**, and it streams - chunked, in
     full - only the files that are **new or changed**. Granularity is whole

--- a/csharp/src/Cluster/README.md
+++ b/csharp/src/Cluster/README.md
@@ -124,8 +124,18 @@ In Cluster mode every node enforces full Raft:
 - **Commit advancement**: the leader keeps a `matchSeq` per peer; on each
   reported progress it sorts the values plus its own `latestSeq` descending,
   picks the value at quorum index (`majority-1`), and that becomes the new
-  `commitSeq`. Followers receive `leaderCommit` on the next heartbeat and
-  advance theirs accordingly.
+  `commitSeq` - **but only if that entry belongs to the leader's current
+  term** (Raft §5.4.2: entries from previous terms are never committed by
+  counting replicas; they commit implicitly once a current-term entry does).
+  To avoid stalling until the first user write, a new leader immediately puts
+  a no-op marker entry (`RaftClusterNode.LeaderNoOpKey`) in its own term.
+  Followers receive `leaderCommit` on the next heartbeat and advance theirs
+  accordingly.
+- **matchSeq trust**: a heartbeat acknowledgement only confirms the prefix up
+  to `prevLogSeq` (that is what the term check validated); `matchSeq` beyond
+  that advances exclusively through the WAL-stream progress reports, which
+  are trustworthy because the stream is gated by the attach-time consistency
+  check described below.
 
 ---
 
@@ -151,10 +161,16 @@ mapping from "log index" to "WAL seqNo".
 5. The candidate counts grants. As soon as it has `Quorum` votes
    (including its own), it calls `BecomeLeader()`:
    - record a new term-range row at `latestSeq + 1`,
-   - reset every peer's `nextSeq` to `latestSeq + 1`,
+   - reset every peer's `nextSeq` to `latestSeq + 1` **and `matchSeq` to 0**
+     (progress learned during a previous leadership is stale),
+   - write the current-term no-op entry so the commit index can advance,
    - pause the election timer,
    - start the heartbeat loop, which immediately notifies all peers of the new
      term and leader id.
+   The whole campaign is pinned to the term captured at the moment the node
+   became candidate: if any concurrent vote or heartbeat moves the term, the
+   campaign is abandoned rather than re-run under the newer term (where this
+   node may already have granted its vote to someone else).
 6. If the candidate sees any response with a higher term, it steps down to
    Follower for that term.
 7. If the election timer fires again before a quorum, the candidate starts a
@@ -172,6 +188,51 @@ Persistence guarantees during elections:
 This is what makes the algorithm safe across crashes - a candidate that wins
 then dies cannot come back as a follower of a lower term and accept
 conflicting log entries.
+
+---
+
+## Log divergence detection & full resync
+
+Classical Raft repairs a diverged follower by truncating the conflicting
+suffix of its log. A RocksDB WAL cannot be truncated, so divergence is
+handled by rebuilding the whole replica from a leader snapshot instead.
+Three layers detect it:
+
+1. **Attach-time consistency check.** Before a follower starts (or restarts)
+   the WAL stream it calls `CheckLogConsistencyAsync(latestSeq, termAtLatest)`
+   on the leader. The leader confirms that exact `(seq, term)` pair exists in
+   its own log (`RaftClusterNode.CheckFollowerLogConsistency`). A follower
+   that is *ahead* of the leader, or whose tail carries a different term,
+   is told to resync. This is what catches a deposed leader rejoining with
+   uncommitted writes in its WAL.
+2. **Per-batch sequence verification.** While consuming the stream, the
+   follower requires every batch to land at exactly
+   `localLatestSeq + 1`. A gap means the leader's WAL no longer reaches back
+   far enough (e.g. the follower was down past the WAL TTL); an overlap means
+   a stray local write slipped in. Either way: resync.
+3. **Heartbeat prev-term check.** `HandleAppendEntries` compares
+   `prevLogTerm` against the local term map and raises
+   `RaftClusterNode.ResyncRequired` on a mismatch.
+
+The resync itself (`ClusterNodeHost.PerformResyncAsync`):
+
+- `Node.BeginResync()` pauses the election timer and makes the node refuse
+  votes (a voter with a half-rebuilt log could help elect a candidate that
+  lacks committed entries) and answer heartbeats with `"resyncing"` without
+  touching the database;
+- the local DB is disposed and the data directory wiped **except** the
+  `raft/` state directory (term and vote must survive - they are promises);
+- a checkpoint is pulled from the current leader via the chunked
+  `SyncInitialStateAsync` stream, followed by the leader's term map
+  (`GetRaftTermsAsync`) - the restored log is byte-for-byte the leader's log,
+  so the leader's term map is its correct description;
+- `Node.CompleteResync(newDb)` swaps the database in and re-arms the
+  election timer, and the WAL stream re-attaches (passing the attach-time
+  check this time).
+
+Unacknowledged writes that lived in the discarded WAL are gone, which is
+exactly Raft's contract: only **committed** (quorum-acknowledged) writes are
+durable.
 
 ---
 
@@ -219,11 +280,13 @@ There is a small write-visibility window: between the moment the leader
 freezes and the moment it discovers the higher term, it would happily accept
 client writes (it still believes it is leader). Those writes never reach a
 quorum so they never commit; when the node steps down, RocksDB's WAL still
-contains them. They will be **overwritten on resync if the new leader's log
-diverges**: the follower's `HandleAppendEntries` returns
-`Success = false, Reason = "term-mismatch"` and the host code re-snapshots
-from the leader via `SyncInitialStateAsync`. From a client's point of view
-the uncommitted writes simply never happened - they were never acknowledged.
+contains them. The attach-time consistency check (see *Log divergence
+detection & full resync* above) catches the divergent tail when the node
+re-attaches to the new leader, and the replica is rebuilt from a snapshot.
+From a client's point of view the uncommitted writes simply never happened -
+they were never acknowledged. `ClusterTest`'s `hang` scenario exercises
+exactly this path and then proves all three replicas converge to
+byte-identical contents.
 
 This is the standard Raft trade-off: only **committed** writes are durable.
 Uncommitted writes on a deposed leader are silently dropped.
@@ -377,3 +440,17 @@ Tuning notes:
 
 See `Tests/ClusterTest/Program.cs` for a working coordinator that drives the
 four canonical scenarios end-to-end: `election`, `crash`, `hang`, `rejoin`.
+
+The coordinator validates the observable Raft properties while it runs:
+
+- **Election Safety** - every status poll is checked: no two nodes may ever
+  report themselves leader of the same term, and a node's term never goes
+  backwards.
+- **Leader Completeness / durability** - `WriteAsync` acknowledges only after
+  the entry is *committed* (replicated to a quorum); the `crash` and `hang`
+  scenarios then assert every acknowledged key is still readable after the
+  failover.
+- **State Machine Safety** - at the end of each scenario the write load is
+  quiesced, the coordinator waits for every replica to converge to the same
+  log tail with `commitSeq == latestSeq`, and whole-database checksums
+  (`ChecksumAsync`) must be identical on every node.

--- a/csharp/src/Cluster/RaftClusterNode.cs
+++ b/csharp/src/Cluster/RaftClusterNode.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,10 +11,11 @@ namespace RocksDbSharp;
 /// <summary>
 /// Transport-agnostic Raft orchestrator. The MagicOnion service in the test
 /// project owns the network and delegates incoming RPCs into this class
-/// through its three RPC-level entry points:
+/// through its RPC-level entry points:
 ///   - <see cref="HandleRequestVote"/>
 ///   - <see cref="HandleAppendEntries"/>
 ///   - <see cref="HandleObservedLeader"/>
+///   - <see cref="CheckFollowerLogConsistency"/>
 ///
 /// Outgoing RPCs are issued via the <see cref="IPeerTransport"/> delegate that
 /// the host provides during construction. This keeps the cluster library free
@@ -21,9 +23,17 @@ namespace RocksDbSharp;
 /// </summary>
 public sealed class RaftClusterNode : IDisposable
 {
+    /// <summary>
+    /// Key of the marker entry a leader writes immediately after winning an
+    /// election. Raft (§5.4.2) forbids committing entries from previous terms
+    /// by counting replicas, so replicating one current-term entry right away
+    /// lets the commit index advance without waiting for a user write.
+    /// </summary>
+    public static readonly byte[] LeaderNoOpKey = Encoding.UTF8.GetBytes("__raft_noop");
+
     private readonly RaftConfig _config;
     private readonly RaftPersistentState _state;
-    private readonly RocksDb _db;
+    private RocksDb _db;
     private readonly IPeerTransport _transport;
     private readonly ElectionTimer _electionTimer;
     private readonly object _gate = new();
@@ -33,12 +43,22 @@ public sealed class RaftClusterNode : IDisposable
     private RaftRole _role;
     private string? _currentLeaderId;
     private ulong _commitSeq;
-    private Task? _leaderLoop;
+    private CancellationTokenSource? _leaderCts;
+    private bool _resyncing;
     private int _bootstrapInSyncFollowers;
 
     public event EventHandler<LeaderChangedEventArgs>? LeaderChanged;
     public event EventHandler<RoleChangedEventArgs>? RoleChanged;
     public event EventHandler<ModeChangedEventArgs>? ModeChanged;
+
+    /// <summary>
+    /// Raised when this node detects that its log conflicts with the current
+    /// leader's log (a term mismatch at a sequence number both logs contain).
+    /// The RocksDB WAL cannot be truncated, so the host must rebuild this
+    /// replica from a leader snapshot: call <see cref="BeginResync"/>, dispose
+    /// the database, restore a snapshot, then call <see cref="CompleteResync"/>.
+    /// </summary>
+    public event EventHandler? ResyncRequired;
 
     public RaftClusterNode(RaftConfig config, RaftPersistentState state, RocksDb db, IPeerTransport transport)
     {
@@ -78,6 +98,10 @@ public sealed class RaftClusterNode : IDisposable
     public ClusterMode Mode => _state.Mode;
     public ulong CommitSeq => Volatile.Read(ref _commitSeq);
     public IReadOnlyCollection<PeerState> Peers => _peers.Values.ToList();
+    public bool IsResyncing { get { lock (_gate) return _resyncing; } }
+    public int BootstrapInSyncCount => Volatile.Read(ref _bootstrapInSyncFollowers);
+
+    public long GetTermForSeq(ulong seq) => _state.Terms.GetTermForSeq(seq);
 
     public void Start()
     {
@@ -103,8 +127,21 @@ public sealed class RaftClusterNode : IDisposable
     {
         lock (_gate)
         {
+            // While our log is being rebuilt from a snapshot we have nothing to
+            // compare the candidate's log against; granting a vote here could
+            // help elect a candidate that lacks committed entries.
+            if (_resyncing)
+                return new RequestVoteResult(_state.CurrentTerm, false);
+
             if (term > _state.CurrentTerm)
             {
+                // Elections can only be started by nodes already in Cluster
+                // mode, so a higher-term RequestVote proves the promotion
+                // quorum was reached somewhere. Adopt Cluster mode, otherwise
+                // a cluster whose leader promoted and then died before
+                // broadcasting the new mode could never elect a successor.
+                if (_state.Mode == ClusterMode.Bootstrap)
+                    PromoteToClusterLocked();
                 _state.UpdateTermAndVote(term, null);
                 BecomeFollower(null);
             }
@@ -143,60 +180,132 @@ public sealed class RaftClusterNode : IDisposable
         ulong leaderCommit,
         ClusterMode leaderMode)
     {
+        AppendEntriesResult result;
+        bool conflict = false;
         lock (_gate)
         {
             if (term > _state.CurrentTerm)
                 _state.UpdateTermAndVote(term, null);
 
+            // The database is being rebuilt: answer before touching _db.
+            if (_resyncing)
+                return new AppendEntriesResult(_state.CurrentTerm, false, 0, "resyncing");
+
             if (term < _state.CurrentTerm)
                 return new AppendEntriesResult(_state.CurrentTerm, false, _db.GetLatestSequenceNumber(), "stale term");
 
             BecomeFollower(leaderId);
-            _electionTimer.Reset();
 
             // Adopt cluster mode if the leader has promoted.
             if (leaderMode == ClusterMode.Cluster && _state.Mode == ClusterMode.Bootstrap)
-            {
-                _state.SetMode(ClusterMode.Cluster);
-                ModeChanged?.Invoke(this, new ModeChangedEventArgs(ClusterMode.Cluster));
-            }
+                PromoteToClusterLocked();
 
             // log consistency check
             ulong myLatest = _db.GetLatestSequenceNumber();
-            if (prevLogSeq > 0)
+            if (prevLogSeq > 0 && prevLogSeq > myLatest)
             {
-                if (prevLogSeq > myLatest)
-                    return new AppendEntriesResult(_state.CurrentTerm, false, myLatest, "behind");
-
-                long myTerm = _state.Terms.GetTermForSeq(prevLogSeq);
-                if (myTerm != prevLogTerm)
-                    return new AppendEntriesResult(_state.CurrentTerm, false, myLatest, "term-mismatch");
+                result = new AppendEntriesResult(_state.CurrentTerm, false, myLatest, "behind");
             }
-
-            // commit advance
-            ulong newCommit = Math.Min(leaderCommit, myLatest);
-            if (newCommit > Volatile.Read(ref _commitSeq))
-                Volatile.Write(ref _commitSeq, newCommit);
-
-            return new AppendEntriesResult(_state.CurrentTerm, true, myLatest, null);
+            else if (prevLogSeq > 0 && _state.Terms.GetTermForSeq(prevLogSeq) != prevLogTerm)
+            {
+                // Our entry at prevLogSeq disagrees with the leader's. Raft
+                // would truncate the conflicting suffix; a RocksDB WAL cannot
+                // be truncated, so this replica must be rebuilt from a leader
+                // snapshot.
+                conflict = true;
+                result = new AppendEntriesResult(_state.CurrentTerm, false, myLatest, "term-mismatch");
+            }
+            else
+            {
+                ulong newCommit = Math.Min(leaderCommit, myLatest);
+                if (newCommit > _commitSeq)
+                    Volatile.Write(ref _commitSeq, newCommit);
+                result = new AppendEntriesResult(_state.CurrentTerm, true, myLatest, null);
+            }
         }
+
+        if (conflict)
+            ResyncRequired?.Invoke(this, EventArgs.Empty);
+
+        return result;
     }
 
     /// <summary>
-    /// Followers call this when they observe a higher term while consuming
-    /// WAL batches (the existing replication stream is leader → follower, so
-    /// the leader tags its current term on the heartbeat).
+    /// Followers call this when they observe a batch on the WAL stream (the
+    /// existing replication stream is leader → follower, so the leader tags
+    /// its current term and node id on every batch it streams).
     /// </summary>
     public void HandleObservedLeader(string leaderId, long term)
     {
         lock (_gate)
         {
-            if (term >= _state.CurrentTerm)
-            {
+            if (term < _state.CurrentTerm) return;
+            // A leader can never be replaced within its own term; only a
+            // strictly higher term may depose us.
+            if (term == _state.CurrentTerm && _role == RaftRole.Leader) return;
+            if (term > _state.CurrentTerm)
                 _state.UpdateTermAndVote(term, null);
-                BecomeFollower(leaderId);
-                _electionTimer.Reset();
+            BecomeFollower(leaderId);
+        }
+    }
+
+    /// <summary>
+    /// Leader-side half of the stream-attach consistency check. Before a
+    /// follower starts consuming the WAL stream it sends its (latestSeq,
+    /// termAtLatest) pair; the leader confirms that pair exists identically in
+    /// its own log. A follower whose tail diverged (e.g. a deposed leader with
+    /// uncommitted writes) is told to rebuild itself from a snapshot.
+    /// </summary>
+    public LogConsistencyResult CheckFollowerLogConsistency(ulong followerLatestSeq, long followerTermAtLatest)
+    {
+        lock (_gate)
+        {
+            if (_role != RaftRole.Leader || _resyncing)
+                return new LogConsistencyResult(false, false, _state.CurrentTerm);
+
+            if (followerLatestSeq == 0)
+                return new LogConsistencyResult(true, true, _state.CurrentTerm);
+
+            ulong myLatest = _db.GetLatestSequenceNumber();
+            if (followerLatestSeq > myLatest)
+            {
+                // The follower has entries the leader does not: an uncommitted
+                // tail from a previous term. It must resync.
+                return new LogConsistencyResult(true, false, _state.CurrentTerm);
             }
+
+            bool consistent = _state.Terms.GetTermForSeq(followerLatestSeq) == followerTermAtLatest;
+            return new LogConsistencyResult(true, consistent, _state.CurrentTerm);
+        }
+    }
+
+    // ===== Resync lifecycle (host-driven) =====
+
+    /// <summary>
+    /// Puts the node into resync mode: the election timer is paused and all
+    /// vote / append handling answers conservatively without touching the
+    /// database, so the host can safely dispose and rebuild it.
+    /// </summary>
+    public void BeginResync()
+    {
+        lock (_gate)
+        {
+            _resyncing = true;
+            _electionTimer.Pause();
+        }
+    }
+
+    /// <summary>
+    /// Completes a resync with the freshly restored database instance.
+    /// </summary>
+    public void CompleteResync(RocksDb db)
+    {
+        lock (_gate)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+            _resyncing = false;
+            if (_role != RaftRole.Leader)
+                _electionTimer.Reset();
         }
     }
 
@@ -205,9 +314,13 @@ public sealed class RaftClusterNode : IDisposable
     public void RecordFollowerProgress(string nodeId, ulong matchSeq)
     {
         if (!_peers.TryGetValue(nodeId, out var peer)) return;
-        peer.OnAppendSucceeded(matchSeq);
-        TryAdvanceCommit();
-        MaybePromoteToCluster();
+        lock (_gate)
+        {
+            if (_resyncing) return;
+            peer.OnAppendSucceeded(matchSeq);
+            TryAdvanceCommitLocked();
+            MaybePromoteToClusterLocked();
+        }
     }
 
     public void RecordFollowerHeartbeat(string nodeId)
@@ -220,11 +333,7 @@ public sealed class RaftClusterNode : IDisposable
         if (_peers.TryGetValue(nodeId, out var peer)) peer.OnAppendFailed();
     }
 
-    /// <summary>
-    /// Called by the leader's host loop to read the leader's "current commit"
-    /// from a follower's perspective, given the per-peer match seq.
-    /// </summary>
-    private void TryAdvanceCommit()
+    private void TryAdvanceCommitLocked()
     {
         if (_role != RaftRole.Leader) return;
         // sort matchSeqs descending; quorum-th value is the new commitIndex
@@ -232,15 +341,17 @@ public sealed class RaftClusterNode : IDisposable
         seqs.Add(_db.GetLatestSequenceNumber()); // include self
         seqs.Sort((a, b) => b.CompareTo(a));
         int q = _config.Quorum;
-        if (seqs.Count >= q)
-        {
-            ulong newCommit = seqs[q - 1];
-            if (newCommit > Volatile.Read(ref _commitSeq))
-                Volatile.Write(ref _commitSeq, newCommit);
-        }
+        if (seqs.Count < q) return;
+        ulong candidate = seqs[q - 1];
+        if (candidate <= _commitSeq) return;
+        // §5.4.2: a leader may only commit entries from its own term by
+        // counting replicas; entries from earlier terms become committed
+        // implicitly once a current-term entry is committed.
+        if (_state.Terms.GetTermForSeq(candidate) != _state.CurrentTerm) return;
+        Volatile.Write(ref _commitSeq, candidate);
     }
 
-    private void MaybePromoteToCluster()
+    private void MaybePromoteToClusterLocked()
     {
         if (_state.Mode != ClusterMode.Bootstrap) return;
         if (_role != RaftRole.Leader) return;
@@ -255,12 +366,16 @@ public sealed class RaftClusterNode : IDisposable
         Volatile.Write(ref _bootstrapInSyncFollowers, inSync);
         if (inSync >= _config.BootstrapPromotionQuorum)
         {
-            _state.SetMode(ClusterMode.Cluster);
-            ModeChanged?.Invoke(this, new ModeChangedEventArgs(ClusterMode.Cluster));
+            PromoteToClusterLocked();
         }
     }
 
-    public int BootstrapInSyncCount => Volatile.Read(ref _bootstrapInSyncFollowers);
+    private void PromoteToClusterLocked()
+    {
+        if (_state.Mode == ClusterMode.Cluster) return;
+        _state.SetMode(ClusterMode.Cluster);
+        ModeChanged?.Invoke(this, new ModeChangedEventArgs(ClusterMode.Cluster));
+    }
 
     // ===== State transitions =====
 
@@ -270,14 +385,11 @@ public sealed class RaftClusterNode : IDisposable
         bool leaderChanged = _currentLeaderId != leaderId;
         _role = RaftRole.Follower;
         _currentLeaderId = leaderId;
-        if (_leaderLoop != null)
-        {
-            // leader loop watches _role and exits on its own
-            _leaderLoop = null;
-        }
+        _leaderCts?.Cancel();
+        _leaderCts = null;
         if (roleChanged) RoleChanged?.Invoke(this, new RoleChangedEventArgs(_role, _state.CurrentTerm));
         if (leaderChanged) LeaderChanged?.Invoke(this, new LeaderChangedEventArgs(leaderId, _state.CurrentTerm));
-        _electionTimer.Reset();
+        if (!_resyncing) _electionTimer.Reset();
     }
 
     private void BecomeCandidate()
@@ -294,8 +406,14 @@ public sealed class RaftClusterNode : IDisposable
         _role = RaftRole.Leader;
         _currentLeaderId = _config.NodeId;
         ulong nextSeq = _db.GetLatestSequenceNumber() + 1;
-        foreach (var p in _peers.Values) p.RewindOnConflict(nextSeq);
+        // matchSeq must be reset to 0 on every election: values learned during
+        // a previous leadership are stale and could falsely advance the commit
+        // index before this term replicated anything.
+        foreach (var p in _peers.Values) p.ResetForNewTerm(nextSeq);
         _state.RecordTermRange(nextSeq, _state.CurrentTerm);
+        // Replicate one entry from the new term right away so the commit index
+        // can advance past entries inherited from previous terms (§5.4.2).
+        _db.Put(LeaderNoOpKey, Encoding.UTF8.GetBytes(_state.CurrentTerm.ToString()));
         RoleChanged?.Invoke(this, new RoleChangedEventArgs(_role, _state.CurrentTerm));
         LeaderChanged?.Invoke(this, new LeaderChangedEventArgs(_config.NodeId, _state.CurrentTerm));
         _electionTimer.Pause();
@@ -304,7 +422,12 @@ public sealed class RaftClusterNode : IDisposable
 
     private void StartLeaderLoop()
     {
-        _leaderLoop = Task.Run(() => LeaderHeartbeatLoopAsync(_cts.Token));
+        // Cancel any loop left over from a previous leadership so two loops
+        // never run concurrently.
+        _leaderCts?.Cancel();
+        _leaderCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+        var token = _leaderCts.Token;
+        _ = Task.Run(() => LeaderHeartbeatLoopAsync(token));
     }
 
     private async Task LeaderHeartbeatLoopAsync(CancellationToken ct)
@@ -315,7 +438,6 @@ public sealed class RaftClusterNode : IDisposable
             {
                 lock (_gate) { if (_role != RaftRole.Leader) break; }
 
-                ulong latest = _db.GetLatestSequenceNumber();
                 ulong commit = Volatile.Read(ref _commitSeq);
                 long term = _state.CurrentTerm;
                 var leaderMode = _state.Mode;
@@ -325,40 +447,7 @@ public sealed class RaftClusterNode : IDisposable
                     ulong prevLogSeq = peer.NextSeq > 0 ? peer.NextSeq - 1 : 0;
                     long prevLogTerm = _state.Terms.GetTermForSeq(prevLogSeq);
                     var beat = new HeartbeatPayload(term, _config.NodeId, prevLogSeq, prevLogTerm, commit, leaderMode);
-                    _ = Task.Run(async () =>
-                    {
-                        try
-                        {
-                            var resp = await _transport.SendHeartbeatAsync(peer.Member, beat, ct).ConfigureAwait(false);
-                            if (resp == null)
-                            {
-                                peer.OnAppendFailed();
-                                return;
-                            }
-                            if (resp.Term > _state.CurrentTerm)
-                            {
-                                lock (_gate)
-                                {
-                                    _state.UpdateTermAndVote(resp.Term, null);
-                                    BecomeFollower(null);
-                                }
-                                return;
-                            }
-                            if (resp.Success)
-                            {
-                                peer.OnAppendSucceeded(resp.LastSeq);
-                                TryAdvanceCommit();
-                                MaybePromoteToCluster();
-                            }
-                            else
-                            {
-                                // conflict – pull nextSeq back; the WAL streamer
-                                // running separately will fall back to snapshot.
-                                peer.RewindOnConflict(Math.Max(1, resp.LastSeq));
-                            }
-                        }
-                        catch { peer.OnAppendFailed(); }
-                    }, ct);
+                    _ = SendHeartbeatToPeerAsync(peer, beat, ct);
                 }
 
                 await Task.Delay(_config.HeartbeatIntervalMs, ct).ConfigureAwait(false);
@@ -367,11 +456,63 @@ public sealed class RaftClusterNode : IDisposable
         catch (OperationCanceledException) { }
     }
 
+    private async Task SendHeartbeatToPeerAsync(PeerState peer, HeartbeatPayload beat, CancellationToken ct)
+    {
+        try
+        {
+            var resp = await _transport.SendHeartbeatAsync(peer.Member, beat, ct).ConfigureAwait(false);
+            if (resp == null)
+            {
+                peer.OnAppendFailed();
+                return;
+            }
+            if (resp.Term > _state.CurrentTerm)
+            {
+                lock (_gate)
+                {
+                    if (resp.Term > _state.CurrentTerm)
+                    {
+                        _state.UpdateTermAndVote(resp.Term, null);
+                        BecomeFollower(null);
+                    }
+                }
+                return;
+            }
+            if (resp.Success)
+            {
+                lock (_gate)
+                {
+                    // Only the prefix ending at PrevLogSeq has been validated
+                    // against our log. Anything past it is confirmed by the
+                    // WAL-stream progress reports, not by the heartbeat.
+                    peer.OnAppendSucceeded(beat.PrevLogSeq);
+                    TryAdvanceCommitLocked();
+                    MaybePromoteToClusterLocked();
+                }
+            }
+            else if (resp.Reason == "behind")
+            {
+                // The follower's log is shorter; probe at its tip next time.
+                peer.RewindOnConflict(Math.Max(1, resp.LastSeq + 1));
+            }
+            else
+            {
+                // term-mismatch (the follower resyncs itself) or resyncing:
+                // treat the peer as unreachable until it comes back.
+                peer.OnAppendFailed();
+            }
+        }
+        catch { peer.OnAppendFailed(); }
+    }
+
     private void OnElectionTimeout()
     {
+        long electionTerm;
+        ulong lastLogSeq;
+        long lastLogTerm;
         lock (_gate)
         {
-            if (_role == RaftRole.Leader) return;
+            if (_role == RaftRole.Leader || _resyncing) return;
             if (_state.Mode == ClusterMode.Bootstrap)
             {
                 // While in Bootstrap mode the cluster has not yet promoted; only
@@ -380,24 +521,26 @@ public sealed class RaftClusterNode : IDisposable
                 return;
             }
             BecomeCandidate();
+            // The campaign is bound to the exact term in which we became
+            // candidate. Capturing it outside this lock would let a concurrent
+            // vote or heartbeat move the term forward and make us campaign in
+            // a term where we may already have voted for someone else.
+            electionTerm = _state.CurrentTerm;
+            lastLogSeq = _db.GetLatestSequenceNumber();
+            lastLogTerm = _state.Terms.GetTermForSeq(lastLogSeq);
+            _electionTimer.Reset();
         }
 
-        _ = Task.Run(RunElectionAsync);
+        _ = Task.Run(() => RunElectionAsync(electionTerm, lastLogSeq, lastLogTerm));
     }
 
-    private async Task RunElectionAsync()
+    private async Task RunElectionAsync(long term, ulong lastLogSeq, long lastLogTerm)
     {
-        long term;
-        ulong lastLogSeq;
-        long lastLogTerm;
         List<ClusterMember> peers;
         lock (_gate)
         {
-            term = _state.CurrentTerm;
-            lastLogSeq = _db.GetLatestSequenceNumber();
-            lastLogTerm = _state.Terms.GetTermForSeq(lastLogSeq);
+            if (_role != RaftRole.Candidate || _state.CurrentTerm != term) return;
             peers = _peers.Values.Select(p => p.Member).ToList();
-            _electionTimer.Reset();
         }
 
         int votes = 1; // self
@@ -423,8 +566,11 @@ public sealed class RaftClusterNode : IDisposable
             {
                 lock (_gate)
                 {
-                    _state.UpdateTermAndVote(resp.Term, null);
-                    BecomeFollower(null);
+                    if (resp.Term > _state.CurrentTerm)
+                    {
+                        _state.UpdateTermAndVote(resp.Term, null);
+                        BecomeFollower(null);
+                    }
                 }
                 return;
             }
@@ -450,6 +596,7 @@ public sealed class RaftClusterNode : IDisposable
 public sealed record RequestVoteResult(long Term, bool VoteGranted);
 public sealed record AppendEntriesResult(long Term, bool Success, ulong LastSeq, string? Reason);
 public sealed record HeartbeatPayload(long Term, string LeaderId, ulong PrevLogSeq, long PrevLogTerm, ulong LeaderCommit, ClusterMode LeaderMode);
+public sealed record LogConsistencyResult(bool IsLeader, bool Consistent, long Term);
 
 public interface IPeerTransport
 {

--- a/csharp/src/Cluster/RaftClusterNode.cs
+++ b/csharp/src/Cluster/RaftClusterNode.cs
@@ -1,0 +1,459 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RocksDbSharp;
+
+/// <summary>
+/// Transport-agnostic Raft orchestrator. The MagicOnion service in the test
+/// project owns the network and delegates incoming RPCs into this class
+/// through its three RPC-level entry points:
+///   - <see cref="HandleRequestVote"/>
+///   - <see cref="HandleAppendEntries"/>
+///   - <see cref="HandleObservedLeader"/>
+///
+/// Outgoing RPCs are issued via the <see cref="IPeerTransport"/> delegate that
+/// the host provides during construction. This keeps the cluster library free
+/// of MagicOnion / gRPC types.
+/// </summary>
+public sealed class RaftClusterNode : IDisposable
+{
+    private readonly RaftConfig _config;
+    private readonly RaftPersistentState _state;
+    private readonly RocksDb _db;
+    private readonly IPeerTransport _transport;
+    private readonly ElectionTimer _electionTimer;
+    private readonly object _gate = new();
+    private readonly Dictionary<string, PeerState> _peers;
+    private readonly CancellationTokenSource _cts = new();
+
+    private RaftRole _role;
+    private string? _currentLeaderId;
+    private ulong _commitSeq;
+    private Task? _leaderLoop;
+    private int _bootstrapInSyncFollowers;
+
+    public event EventHandler<LeaderChangedEventArgs>? LeaderChanged;
+    public event EventHandler<RoleChangedEventArgs>? RoleChanged;
+    public event EventHandler<ModeChangedEventArgs>? ModeChanged;
+
+    public RaftClusterNode(RaftConfig config, RaftPersistentState state, RocksDb db, IPeerTransport transport)
+    {
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+        _state = state ?? throw new ArgumentNullException(nameof(state));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+
+        _peers = _config.Peers.ToDictionary(
+            p => p.NodeId,
+            p => new PeerState(p, db.GetLatestSequenceNumber() + 1));
+
+        _electionTimer = new ElectionTimer(_config.ElectionTimeoutMinMs, _config.ElectionTimeoutMaxMs, OnElectionTimeout);
+
+        if (_config.BootstrapPrimary && _state.Mode == ClusterMode.Bootstrap)
+        {
+            // Bootstrap primary: act as leader without holding an election.
+            // Term is recorded on first promotion to cluster-mode.
+            _role = RaftRole.Leader;
+            _currentLeaderId = _config.NodeId;
+            if (_state.CurrentTerm == 0)
+            {
+                _state.UpdateTermAndVote(1, _config.NodeId);
+                _state.RecordTermRange(_db.GetLatestSequenceNumber() + 1, 1);
+            }
+        }
+        else
+        {
+            _role = RaftRole.Follower;
+        }
+    }
+
+    public string NodeId => _config.NodeId;
+    public RaftRole Role { get { lock (_gate) return _role; } }
+    public long CurrentTerm => _state.CurrentTerm;
+    public string? CurrentLeaderId { get { lock (_gate) return _currentLeaderId; } }
+    public ClusterMode Mode => _state.Mode;
+    public ulong CommitSeq => Volatile.Read(ref _commitSeq);
+    public IReadOnlyCollection<PeerState> Peers => _peers.Values.ToList();
+
+    public void Start()
+    {
+        if (_role == RaftRole.Leader)
+        {
+            StartLeaderLoop();
+        }
+        else
+        {
+            _electionTimer.Start();
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _electionTimer.Dispose();
+    }
+
+    // ===== Incoming RPC handlers =====
+
+    public RequestVoteResult HandleRequestVote(long term, string candidateId, ulong lastLogSeq, long lastLogTerm)
+    {
+        lock (_gate)
+        {
+            if (term > _state.CurrentTerm)
+            {
+                _state.UpdateTermAndVote(term, null);
+                BecomeFollower(null);
+            }
+
+            if (term < _state.CurrentTerm)
+                return new RequestVoteResult(_state.CurrentTerm, false);
+
+            // In Bootstrap mode we do not honor election attempts: the bootstrap
+            // primary is fixed. Followers will reject votes so a partition does
+            // not accidentally produce a leader before initialization completes.
+            if (_state.Mode == ClusterMode.Bootstrap)
+                return new RequestVoteResult(_state.CurrentTerm, false);
+
+            var votedFor = _state.VotedFor;
+            if (votedFor != null && votedFor != candidateId)
+                return new RequestVoteResult(_state.CurrentTerm, false);
+
+            // candidate's log must be at least as up-to-date as ours
+            ulong myLastSeq = _db.GetLatestSequenceNumber();
+            long myLastTerm = _state.Terms.GetTermForSeq(myLastSeq);
+            bool upToDate = lastLogTerm > myLastTerm
+                            || (lastLogTerm == myLastTerm && lastLogSeq >= myLastSeq);
+            if (!upToDate) return new RequestVoteResult(_state.CurrentTerm, false);
+
+            _state.UpdateTermAndVote(term, candidateId);
+            _electionTimer.Reset();
+            return new RequestVoteResult(_state.CurrentTerm, true);
+        }
+    }
+
+    public AppendEntriesResult HandleAppendEntries(
+        long term,
+        string leaderId,
+        ulong prevLogSeq,
+        long prevLogTerm,
+        ulong leaderCommit,
+        ClusterMode leaderMode)
+    {
+        lock (_gate)
+        {
+            if (term > _state.CurrentTerm)
+                _state.UpdateTermAndVote(term, null);
+
+            if (term < _state.CurrentTerm)
+                return new AppendEntriesResult(_state.CurrentTerm, false, _db.GetLatestSequenceNumber(), "stale term");
+
+            BecomeFollower(leaderId);
+            _electionTimer.Reset();
+
+            // Adopt cluster mode if the leader has promoted.
+            if (leaderMode == ClusterMode.Cluster && _state.Mode == ClusterMode.Bootstrap)
+            {
+                _state.SetMode(ClusterMode.Cluster);
+                ModeChanged?.Invoke(this, new ModeChangedEventArgs(ClusterMode.Cluster));
+            }
+
+            // log consistency check
+            ulong myLatest = _db.GetLatestSequenceNumber();
+            if (prevLogSeq > 0)
+            {
+                if (prevLogSeq > myLatest)
+                    return new AppendEntriesResult(_state.CurrentTerm, false, myLatest, "behind");
+
+                long myTerm = _state.Terms.GetTermForSeq(prevLogSeq);
+                if (myTerm != prevLogTerm)
+                    return new AppendEntriesResult(_state.CurrentTerm, false, myLatest, "term-mismatch");
+            }
+
+            // commit advance
+            ulong newCommit = Math.Min(leaderCommit, myLatest);
+            if (newCommit > Volatile.Read(ref _commitSeq))
+                Volatile.Write(ref _commitSeq, newCommit);
+
+            return new AppendEntriesResult(_state.CurrentTerm, true, myLatest, null);
+        }
+    }
+
+    /// <summary>
+    /// Followers call this when they observe a higher term while consuming
+    /// WAL batches (the existing replication stream is leader → follower, so
+    /// the leader tags its current term on the heartbeat).
+    /// </summary>
+    public void HandleObservedLeader(string leaderId, long term)
+    {
+        lock (_gate)
+        {
+            if (term >= _state.CurrentTerm)
+            {
+                _state.UpdateTermAndVote(term, null);
+                BecomeFollower(leaderId);
+                _electionTimer.Reset();
+            }
+        }
+    }
+
+    // ===== Leader-only: log replication advance =====
+
+    public void RecordFollowerProgress(string nodeId, ulong matchSeq)
+    {
+        if (!_peers.TryGetValue(nodeId, out var peer)) return;
+        peer.OnAppendSucceeded(matchSeq);
+        TryAdvanceCommit();
+        MaybePromoteToCluster();
+    }
+
+    public void RecordFollowerHeartbeat(string nodeId)
+    {
+        if (_peers.TryGetValue(nodeId, out var peer)) peer.OnHeartbeatAcknowledged();
+    }
+
+    public void RecordFollowerUnreachable(string nodeId)
+    {
+        if (_peers.TryGetValue(nodeId, out var peer)) peer.OnAppendFailed();
+    }
+
+    /// <summary>
+    /// Called by the leader's host loop to read the leader's "current commit"
+    /// from a follower's perspective, given the per-peer match seq.
+    /// </summary>
+    private void TryAdvanceCommit()
+    {
+        if (_role != RaftRole.Leader) return;
+        // sort matchSeqs descending; quorum-th value is the new commitIndex
+        var seqs = _peers.Values.Select(p => p.MatchSeq).ToList();
+        seqs.Add(_db.GetLatestSequenceNumber()); // include self
+        seqs.Sort((a, b) => b.CompareTo(a));
+        int q = _config.Quorum;
+        if (seqs.Count >= q)
+        {
+            ulong newCommit = seqs[q - 1];
+            if (newCommit > Volatile.Read(ref _commitSeq))
+                Volatile.Write(ref _commitSeq, newCommit);
+        }
+    }
+
+    private void MaybePromoteToCluster()
+    {
+        if (_state.Mode != ClusterMode.Bootstrap) return;
+        if (_role != RaftRole.Leader) return;
+
+        ulong latest = _db.GetLatestSequenceNumber();
+        ulong threshold = _config.BootstrapInSyncLagThreshold;
+        int inSync = 1; // self
+        foreach (var p in _peers.Values)
+        {
+            if (p.MatchSeq + threshold >= latest && p.MatchSeq > 0) inSync++;
+        }
+        Volatile.Write(ref _bootstrapInSyncFollowers, inSync);
+        if (inSync >= _config.BootstrapPromotionQuorum)
+        {
+            _state.SetMode(ClusterMode.Cluster);
+            ModeChanged?.Invoke(this, new ModeChangedEventArgs(ClusterMode.Cluster));
+        }
+    }
+
+    public int BootstrapInSyncCount => Volatile.Read(ref _bootstrapInSyncFollowers);
+
+    // ===== State transitions =====
+
+    private void BecomeFollower(string? leaderId)
+    {
+        bool roleChanged = _role != RaftRole.Follower;
+        bool leaderChanged = _currentLeaderId != leaderId;
+        _role = RaftRole.Follower;
+        _currentLeaderId = leaderId;
+        if (_leaderLoop != null)
+        {
+            // leader loop watches _role and exits on its own
+            _leaderLoop = null;
+        }
+        if (roleChanged) RoleChanged?.Invoke(this, new RoleChangedEventArgs(_role, _state.CurrentTerm));
+        if (leaderChanged) LeaderChanged?.Invoke(this, new LeaderChangedEventArgs(leaderId, _state.CurrentTerm));
+        _electionTimer.Reset();
+    }
+
+    private void BecomeCandidate()
+    {
+        _role = RaftRole.Candidate;
+        _state.UpdateTermAndVote(_state.CurrentTerm + 1, _config.NodeId);
+        _currentLeaderId = null;
+        RoleChanged?.Invoke(this, new RoleChangedEventArgs(_role, _state.CurrentTerm));
+        LeaderChanged?.Invoke(this, new LeaderChangedEventArgs(null, _state.CurrentTerm));
+    }
+
+    private void BecomeLeader()
+    {
+        _role = RaftRole.Leader;
+        _currentLeaderId = _config.NodeId;
+        ulong nextSeq = _db.GetLatestSequenceNumber() + 1;
+        foreach (var p in _peers.Values) p.RewindOnConflict(nextSeq);
+        _state.RecordTermRange(nextSeq, _state.CurrentTerm);
+        RoleChanged?.Invoke(this, new RoleChangedEventArgs(_role, _state.CurrentTerm));
+        LeaderChanged?.Invoke(this, new LeaderChangedEventArgs(_config.NodeId, _state.CurrentTerm));
+        _electionTimer.Pause();
+        StartLeaderLoop();
+    }
+
+    private void StartLeaderLoop()
+    {
+        _leaderLoop = Task.Run(() => LeaderHeartbeatLoopAsync(_cts.Token));
+    }
+
+    private async Task LeaderHeartbeatLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                lock (_gate) { if (_role != RaftRole.Leader) break; }
+
+                ulong latest = _db.GetLatestSequenceNumber();
+                ulong commit = Volatile.Read(ref _commitSeq);
+                long term = _state.CurrentTerm;
+                var leaderMode = _state.Mode;
+
+                foreach (var peer in _peers.Values)
+                {
+                    ulong prevLogSeq = peer.NextSeq > 0 ? peer.NextSeq - 1 : 0;
+                    long prevLogTerm = _state.Terms.GetTermForSeq(prevLogSeq);
+                    var beat = new HeartbeatPayload(term, _config.NodeId, prevLogSeq, prevLogTerm, commit, leaderMode);
+                    _ = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            var resp = await _transport.SendHeartbeatAsync(peer.Member, beat, ct).ConfigureAwait(false);
+                            if (resp == null)
+                            {
+                                peer.OnAppendFailed();
+                                return;
+                            }
+                            if (resp.Term > _state.CurrentTerm)
+                            {
+                                lock (_gate)
+                                {
+                                    _state.UpdateTermAndVote(resp.Term, null);
+                                    BecomeFollower(null);
+                                }
+                                return;
+                            }
+                            if (resp.Success)
+                            {
+                                peer.OnAppendSucceeded(resp.LastSeq);
+                                TryAdvanceCommit();
+                                MaybePromoteToCluster();
+                            }
+                            else
+                            {
+                                // conflict – pull nextSeq back; the WAL streamer
+                                // running separately will fall back to snapshot.
+                                peer.RewindOnConflict(Math.Max(1, resp.LastSeq));
+                            }
+                        }
+                        catch { peer.OnAppendFailed(); }
+                    }, ct);
+                }
+
+                await Task.Delay(_config.HeartbeatIntervalMs, ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private void OnElectionTimeout()
+    {
+        lock (_gate)
+        {
+            if (_role == RaftRole.Leader) return;
+            if (_state.Mode == ClusterMode.Bootstrap)
+            {
+                // While in Bootstrap mode the cluster has not yet promoted; only
+                // the bootstrap primary may be leader, so reset and wait.
+                _electionTimer.Reset();
+                return;
+            }
+            BecomeCandidate();
+        }
+
+        _ = Task.Run(RunElectionAsync);
+    }
+
+    private async Task RunElectionAsync()
+    {
+        long term;
+        ulong lastLogSeq;
+        long lastLogTerm;
+        List<ClusterMember> peers;
+        lock (_gate)
+        {
+            term = _state.CurrentTerm;
+            lastLogSeq = _db.GetLatestSequenceNumber();
+            lastLogTerm = _state.Terms.GetTermForSeq(lastLogSeq);
+            peers = _peers.Values.Select(p => p.Member).ToList();
+            _electionTimer.Reset();
+        }
+
+        int votes = 1; // self
+        int needed = _config.Quorum;
+        var tasks = peers.Select(async p =>
+        {
+            try
+            {
+                var resp = await _transport.SendRequestVoteAsync(p, term, _config.NodeId, lastLogSeq, lastLogTerm, _cts.Token)
+                                           .ConfigureAwait(false);
+                return resp;
+            }
+            catch { return null; }
+        }).ToList();
+
+        while (tasks.Count > 0)
+        {
+            var done = await Task.WhenAny(tasks).ConfigureAwait(false);
+            tasks.Remove(done);
+            var resp = await done.ConfigureAwait(false);
+            if (resp == null) continue;
+            if (resp.Term > term)
+            {
+                lock (_gate)
+                {
+                    _state.UpdateTermAndVote(resp.Term, null);
+                    BecomeFollower(null);
+                }
+                return;
+            }
+            if (resp.VoteGranted)
+            {
+                votes++;
+                if (votes >= needed)
+                {
+                    lock (_gate)
+                    {
+                        // Make sure we are still candidate for this term
+                        if (_role != RaftRole.Candidate || _state.CurrentTerm != term) return;
+                        BecomeLeader();
+                    }
+                    return;
+                }
+            }
+        }
+        // election failed; election timer will fire again
+    }
+}
+
+public sealed record RequestVoteResult(long Term, bool VoteGranted);
+public sealed record AppendEntriesResult(long Term, bool Success, ulong LastSeq, string? Reason);
+public sealed record HeartbeatPayload(long Term, string LeaderId, ulong PrevLogSeq, long PrevLogTerm, ulong LeaderCommit, ClusterMode LeaderMode);
+
+public interface IPeerTransport
+{
+    Task<RequestVoteResult?> SendRequestVoteAsync(ClusterMember peer, long term, string candidateId, ulong lastLogSeq, long lastLogTerm, CancellationToken ct);
+    Task<AppendEntriesResult?> SendHeartbeatAsync(ClusterMember peer, HeartbeatPayload payload, CancellationToken ct);
+}
+#endif

--- a/csharp/src/Cluster/RaftConfig.cs
+++ b/csharp/src/Cluster/RaftConfig.cs
@@ -1,0 +1,71 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RocksDbSharp;
+
+public sealed class RaftConfig
+{
+    public string NodeId { get; }
+    public string Endpoint { get; }
+    public IReadOnlyList<ClusterMember> Peers { get; }
+    public bool BootstrapPrimary { get; }
+
+    public int ElectionTimeoutMinMs { get; }
+    public int ElectionTimeoutMaxMs { get; }
+    public int HeartbeatIntervalMs { get; }
+
+    /// <summary>
+    /// When in Bootstrap mode, how close to the primary (in WAL sequence numbers)
+    /// a follower must be before it is considered "in-sync" and counts towards
+    /// the quorum needed to switch to Cluster mode.
+    /// </summary>
+    public ulong BootstrapInSyncLagThreshold { get; }
+
+    /// <summary>
+    /// Minimum number of voting members that must be in-sync (including the
+    /// bootstrap primary itself) before the cluster switches to Cluster mode.
+    /// Defaults to a strict majority of the configured peers + self.
+    /// </summary>
+    public int BootstrapPromotionQuorum { get; }
+
+    public RaftConfig(
+        string nodeId,
+        string endpoint,
+        IEnumerable<ClusterMember> peers,
+        bool bootstrapPrimary = false,
+        int electionTimeoutMinMs = 1500,
+        int electionTimeoutMaxMs = 3000,
+        int heartbeatIntervalMs = 300,
+        ulong bootstrapInSyncLagThreshold = 1000,
+        int bootstrapPromotionQuorum = -1)
+    {
+        if (string.IsNullOrWhiteSpace(nodeId)) throw new ArgumentException("NodeId required", nameof(nodeId));
+        if (string.IsNullOrWhiteSpace(endpoint)) throw new ArgumentException("Endpoint required", nameof(endpoint));
+        if (electionTimeoutMinMs <= 0) throw new ArgumentOutOfRangeException(nameof(electionTimeoutMinMs));
+        if (electionTimeoutMaxMs < electionTimeoutMinMs) throw new ArgumentOutOfRangeException(nameof(electionTimeoutMaxMs));
+        if (heartbeatIntervalMs <= 0 || heartbeatIntervalMs >= electionTimeoutMinMs)
+            throw new ArgumentOutOfRangeException(nameof(heartbeatIntervalMs), "Heartbeat must be smaller than ElectionTimeoutMin");
+
+        NodeId = nodeId;
+        Endpoint = endpoint;
+        Peers = peers?.ToList() ?? throw new ArgumentNullException(nameof(peers));
+        BootstrapPrimary = bootstrapPrimary;
+        ElectionTimeoutMinMs = electionTimeoutMinMs;
+        ElectionTimeoutMaxMs = electionTimeoutMaxMs;
+        HeartbeatIntervalMs = heartbeatIntervalMs;
+        BootstrapInSyncLagThreshold = bootstrapInSyncLagThreshold;
+
+        int total = Peers.Count + 1;
+        BootstrapPromotionQuorum = bootstrapPromotionQuorum > 0
+            ? bootstrapPromotionQuorum
+            : (total / 2) + 1;
+    }
+
+    /// <summary>
+    /// Quorum threshold (majority) including self.
+    /// </summary>
+    public int Quorum => ((Peers.Count + 1) / 2) + 1;
+}
+#endif

--- a/csharp/src/Cluster/RaftLogTerms.cs
+++ b/csharp/src/Cluster/RaftLogTerms.cs
@@ -19,21 +19,33 @@ public sealed class RaftLogTerms
     private readonly List<(ulong StartSeq, long Term)> _ranges = new();
     private readonly object _gate = new();
 
-    public void Record(ulong startSeq, long term)
+    /// <summary>
+    /// Records that entries from <paramref name="startSeq"/> onwards belong to
+    /// <paramref name="term"/>. Returns true if the map changed. Stale or
+    /// out-of-order records are ignored rather than thrown on, because the
+    /// WAL-stream consumer may legitimately re-observe old batches after a
+    /// reconnect.
+    /// </summary>
+    public bool Record(ulong startSeq, long term)
     {
         lock (_gate)
         {
-            // If this term already started earlier, ignore - we only record the
-            // first sequence number of each term.
             if (_ranges.Count > 0)
             {
                 var last = _ranges[^1];
-                if (last.Term == term) return;
-                if (last.StartSeq > startSeq)
-                    throw new InvalidOperationException(
-                        $"Term ranges must be monotonic; new range starts at {startSeq} but last starts at {last.StartSeq}");
+                // We only record the first sequence number of each term.
+                if (term <= last.Term) return false;
+                if (startSeq < last.StartSeq) return false;
+                if (startSeq == last.StartSeq)
+                {
+                    // The previous term produced no entries (its range starts
+                    // beyond the log tail); the new term supersedes it.
+                    _ranges[^1] = (startSeq, term);
+                    return true;
+                }
             }
             _ranges.Add((startSeq, term));
+            return true;
         }
     }
 

--- a/csharp/src/Cluster/RaftLogTerms.cs
+++ b/csharp/src/Cluster/RaftLogTerms.cs
@@ -1,0 +1,103 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace RocksDbSharp;
+
+/// <summary>
+/// Sparse map of "log entry term" for the WAL. Each new term records the
+/// starting WAL sequence number at which it became active. To look up the
+/// term of any sequence number we binary-search for the latest range that
+/// starts at or before it.
+/// </summary>
+public sealed class RaftLogTerms
+{
+    // sorted by StartSeq ascending
+    private readonly List<(ulong StartSeq, long Term)> _ranges = new();
+    private readonly object _gate = new();
+
+    public void Record(ulong startSeq, long term)
+    {
+        lock (_gate)
+        {
+            // If this term already started earlier, ignore - we only record the
+            // first sequence number of each term.
+            if (_ranges.Count > 0)
+            {
+                var last = _ranges[^1];
+                if (last.Term == term) return;
+                if (last.StartSeq > startSeq)
+                    throw new InvalidOperationException(
+                        $"Term ranges must be monotonic; new range starts at {startSeq} but last starts at {last.StartSeq}");
+            }
+            _ranges.Add((startSeq, term));
+        }
+    }
+
+    /// <summary>
+    /// Returns the term assigned to the WAL entry at <paramref name="seq"/>.
+    /// Returns 0 if there are no recorded ranges or seq is before the first.
+    /// </summary>
+    public long GetTermForSeq(ulong seq)
+    {
+        lock (_gate)
+        {
+            if (_ranges.Count == 0) return 0;
+            // binary search for the largest StartSeq <= seq
+            int lo = 0, hi = _ranges.Count - 1, idx = -1;
+            while (lo <= hi)
+            {
+                int mid = (lo + hi) >> 1;
+                if (_ranges[mid].StartSeq <= seq)
+                {
+                    idx = mid;
+                    lo = mid + 1;
+                }
+                else
+                {
+                    hi = mid - 1;
+                }
+            }
+            return idx < 0 ? 0 : _ranges[idx].Term;
+        }
+    }
+
+    public (ulong StartSeq, long Term) GetLast()
+    {
+        lock (_gate)
+        {
+            return _ranges.Count == 0 ? (0UL, 0L) : _ranges[^1];
+        }
+    }
+
+    public string Serialize()
+    {
+        lock (_gate)
+        {
+            var sb = new StringBuilder();
+            foreach (var (s, t) in _ranges) sb.Append(s).Append(',').Append(t).Append('\n');
+            return sb.ToString();
+        }
+    }
+
+    public static RaftLogTerms Deserialize(string content)
+    {
+        var t = new RaftLogTerms();
+        if (string.IsNullOrEmpty(content)) return t;
+        foreach (var line in content.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = line.Split(',');
+            if (parts.Length != 2) continue;
+            if (ulong.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var s) &&
+                long.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var term))
+            {
+                t._ranges.Add((s, term));
+            }
+        }
+        return t;
+    }
+}
+#endif

--- a/csharp/src/Cluster/RaftPersistentState.cs
+++ b/csharp/src/Cluster/RaftPersistentState.cs
@@ -14,8 +14,9 @@ namespace RocksDbSharp;
 ///  - the per-seqNo term log (so a recovering follower can answer
 ///    "what was the term of log entry X?")
 ///
-/// Everything is written atomically through a temp-file + rename so a crash
-/// mid-write cannot leave us with corrupt state.
+/// Everything is written through a temp-file that is flushed to disk and then
+/// renamed over the target, so a crash mid-write cannot leave us with corrupt
+/// state and an acknowledged vote/term can never be rolled back by power loss.
 /// </summary>
 public sealed class RaftPersistentState
 {
@@ -49,7 +50,10 @@ public sealed class RaftPersistentState
         get => (ClusterMode)Volatile.Read(ref _mode);
     }
 
-    public RaftLogTerms Terms => _terms;
+    public RaftLogTerms Terms
+    {
+        get { lock (_gate) return _terms; }
+    }
 
     public void SetMode(ClusterMode mode)
     {
@@ -88,15 +92,28 @@ public sealed class RaftPersistentState
 
     /// <summary>
     /// Record the term of a log range starting at <paramref name="startSeq"/>.
-    /// Persists immediately.
+    /// Persists immediately if the map changed.
     /// </summary>
     public void RecordTermRange(ulong startSeq, long term)
     {
         lock (_gate)
         {
-            _terms.Record(startSeq, term);
-            File.WriteAllText(TempPath(_termsPath), _terms.Serialize());
-            File.Move(TempPath(_termsPath), _termsPath, overwrite: true);
+            if (_terms.Record(startSeq, term))
+                AtomicWrite(_termsPath, _terms.Serialize());
+        }
+    }
+
+    /// <summary>
+    /// Replaces the whole term map. Used after a snapshot restore, when the
+    /// local log is byte-for-byte the leader's log so the leader's term map is
+    /// the correct description of it.
+    /// </summary>
+    public void ReplaceTerms(RaftLogTerms terms)
+    {
+        lock (_gate)
+        {
+            _terms = terms ?? throw new ArgumentNullException(nameof(terms));
+            AtomicWrite(_termsPath, _terms.Serialize());
         }
     }
 
@@ -106,10 +123,21 @@ public sealed class RaftPersistentState
         sb.Append(_currentTerm).Append('\n');
         sb.Append(_votedFor ?? string.Empty).Append('\n');
         sb.Append(_mode).Append('\n');
+        AtomicWrite(_statePath, sb.ToString());
+    }
 
-        string tmp = TempPath(_statePath);
-        File.WriteAllText(tmp, sb.ToString());
-        File.Move(tmp, _statePath, overwrite: true);
+    private static void AtomicWrite(string path, string content)
+    {
+        string tmp = path + ".tmp";
+        using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+            var bytes = Encoding.UTF8.GetBytes(content);
+            fs.Write(bytes, 0, bytes.Length);
+            // Raft safety depends on term/vote surviving a crash *before* the
+            // RPC reply leaves this node, so force the data to disk.
+            fs.Flush(flushToDisk: true);
+        }
+        File.Move(tmp, path, overwrite: true);
     }
 
     private void Load()
@@ -144,7 +172,5 @@ public sealed class RaftPersistentState
             }
         }
     }
-
-    private static string TempPath(string path) => path + ".tmp";
 }
 #endif

--- a/csharp/src/Cluster/RaftPersistentState.cs
+++ b/csharp/src/Cluster/RaftPersistentState.cs
@@ -1,0 +1,150 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace RocksDbSharp;
+
+/// <summary>
+/// Persists the bits of Raft state that must survive a process crash:
+///  - currentTerm
+///  - votedFor (in the current term)
+///  - clusterMode (Bootstrap vs Cluster)
+///  - the per-seqNo term log (so a recovering follower can answer
+///    "what was the term of log entry X?")
+///
+/// Everything is written atomically through a temp-file + rename so a crash
+/// mid-write cannot leave us with corrupt state.
+/// </summary>
+public sealed class RaftPersistentState
+{
+    private readonly string _statePath;
+    private readonly string _termsPath;
+    private readonly object _gate = new();
+
+    private long _currentTerm;
+    private string? _votedFor;
+    private int _mode; // ClusterMode
+    private RaftLogTerms _terms;
+
+    public RaftPersistentState(string directory)
+    {
+        Directory.CreateDirectory(directory);
+        _statePath = Path.Combine(directory, "raft.state");
+        _termsPath = Path.Combine(directory, "raft.terms");
+        _terms = new RaftLogTerms();
+        Load();
+    }
+
+    public long CurrentTerm => Interlocked.Read(ref _currentTerm);
+
+    public string? VotedFor
+    {
+        get { lock (_gate) return _votedFor; }
+    }
+
+    public ClusterMode Mode
+    {
+        get => (ClusterMode)Volatile.Read(ref _mode);
+    }
+
+    public RaftLogTerms Terms => _terms;
+
+    public void SetMode(ClusterMode mode)
+    {
+        lock (_gate)
+        {
+            _mode = (int)mode;
+            Persist();
+        }
+    }
+
+    /// <summary>
+    /// Atomically updates currentTerm and votedFor. If the new term is higher
+    /// than the recorded term, votedFor is cleared unless a vote is being cast
+    /// for this same term.
+    /// </summary>
+    public void UpdateTermAndVote(long newTerm, string? newVotedFor)
+    {
+        lock (_gate)
+        {
+            if (newTerm > _currentTerm)
+            {
+                _currentTerm = newTerm;
+                _votedFor = newVotedFor;
+            }
+            else if (newTerm == _currentTerm && newVotedFor != null && _votedFor == null)
+            {
+                _votedFor = newVotedFor;
+            }
+            else
+            {
+                return;
+            }
+            Persist();
+        }
+    }
+
+    /// <summary>
+    /// Record the term of a log range starting at <paramref name="startSeq"/>.
+    /// Persists immediately.
+    /// </summary>
+    public void RecordTermRange(ulong startSeq, long term)
+    {
+        lock (_gate)
+        {
+            _terms.Record(startSeq, term);
+            File.WriteAllText(TempPath(_termsPath), _terms.Serialize());
+            File.Move(TempPath(_termsPath), _termsPath, overwrite: true);
+        }
+    }
+
+    private void Persist()
+    {
+        var sb = new StringBuilder();
+        sb.Append(_currentTerm).Append('\n');
+        sb.Append(_votedFor ?? string.Empty).Append('\n');
+        sb.Append(_mode).Append('\n');
+
+        string tmp = TempPath(_statePath);
+        File.WriteAllText(tmp, sb.ToString());
+        File.Move(tmp, _statePath, overwrite: true);
+    }
+
+    private void Load()
+    {
+        if (File.Exists(_statePath))
+        {
+            try
+            {
+                var lines = File.ReadAllLines(_statePath);
+                if (lines.Length >= 1 && long.TryParse(lines[0], out var t)) _currentTerm = t;
+                if (lines.Length >= 2) _votedFor = string.IsNullOrEmpty(lines[1]) ? null : lines[1];
+                if (lines.Length >= 3 && int.TryParse(lines[2], out var m)) _mode = m;
+            }
+            catch
+            {
+                // corrupt file; start fresh
+                _currentTerm = 0;
+                _votedFor = null;
+                _mode = 0;
+            }
+        }
+
+        if (File.Exists(_termsPath))
+        {
+            try
+            {
+                _terms = RaftLogTerms.Deserialize(File.ReadAllText(_termsPath));
+            }
+            catch
+            {
+                _terms = new RaftLogTerms();
+            }
+        }
+    }
+
+    private static string TempPath(string path) => path + ".tmp";
+}
+#endif

--- a/csharp/src/Cluster/RaftRole.cs
+++ b/csharp/src/Cluster/RaftRole.cs
@@ -1,0 +1,10 @@
+#if NET5_0_OR_GREATER
+namespace RocksDbSharp;
+
+public enum RaftRole
+{
+    Follower = 0,
+    Candidate = 1,
+    Leader = 2,
+}
+#endif

--- a/csharp/src/Replication/ReplicationClasses.cs
+++ b/csharp/src/Replication/ReplicationClasses.cs
@@ -44,17 +44,44 @@ namespace RocksDbSharp
             {
                 foreach (var filePath in Directory.GetFiles(_tempPath))
                 {
-                    var fileName = Path.GetFileName(filePath);
-                    var fileInfo = new FileInfo(filePath);
-                    var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                    yield return new ReplicationFile
-                    {
-                        FileName = fileName,
-                        FileSize = (ulong)fileInfo.Length,
-                        FileStream = stream
-                    };
+                    yield return OpenFile(Path.GetFileName(filePath));
                 }
             }
+        }
+
+        /// <summary>
+        /// Lists the checkpoint's files with size and, for immutable files,
+        /// a content hash - the source-side half of a per-file delta transfer.
+        /// </summary>
+        public List<ReplicationFileInfo> GetManifest()
+        {
+            var result = new List<ReplicationFileInfo>();
+            foreach (var filePath in Directory.GetFiles(_tempPath))
+            {
+                var fileInfo = new FileInfo(filePath);
+                result.Add(new ReplicationFileInfo
+                {
+                    FileName = fileInfo.Name,
+                    Size = fileInfo.Length,
+                    Hash = ReplicationDelta.IsImmutableFile(fileInfo.Name)
+                        ? ReplicationDelta.ComputeFileHash(filePath)
+                        : string.Empty,
+                });
+            }
+            return result;
+        }
+
+        public ReplicationFile OpenFile(string fileName)
+        {
+            var filePath = Path.Combine(_tempPath, fileName);
+            var fileInfo = new FileInfo(filePath);
+            var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            return new ReplicationFile
+            {
+                FileName = fileName,
+                FileSize = (ulong)fileInfo.Length,
+                FileStream = stream
+            };
         }
 
         public void Dispose()

--- a/csharp/src/Replication/ReplicationClasses.cs
+++ b/csharp/src/Replication/ReplicationClasses.cs
@@ -50,8 +50,11 @@ namespace RocksDbSharp
         }
 
         /// <summary>
-        /// Lists the checkpoint's files with size and, for immutable files,
-        /// a content hash - the source-side half of a per-file delta transfer.
+        /// Lists the checkpoint's files with their sizes - the source-side
+        /// half of a per-file delta transfer. Content hashes are deliberately
+        /// not computed here; candidates are verified on demand through the
+        /// hash-request exchange (<see cref="ReplicationDelta.TryHashCandidate"/>),
+        /// so files that cannot match by name + size are never hashed.
         /// </summary>
         public List<ReplicationFileInfo> GetManifest()
         {
@@ -63,9 +66,7 @@ namespace RocksDbSharp
                 {
                     FileName = fileInfo.Name,
                     Size = fileInfo.Length,
-                    Hash = ReplicationDelta.IsImmutableFile(fileInfo.Name)
-                        ? ReplicationDelta.ComputeFileHash(filePath)
-                        : string.Empty,
+                    Hash = string.Empty,
                 });
             }
             return result;

--- a/csharp/src/Replication/ReplicationClasses.cs
+++ b/csharp/src/Replication/ReplicationClasses.cs
@@ -53,7 +53,7 @@ namespace RocksDbSharp
         /// Lists the checkpoint's files with their sizes - the source-side
         /// half of a per-file delta transfer. Content hashes are deliberately
         /// not computed here; candidates are verified on demand through the
-        /// hash-request exchange (<see cref="ReplicationDelta.TryHashCandidate"/>),
+        /// hash-request exchange (<see cref="ReplicationDelta.TryHashCandidateAsync"/>),
         /// so files that cannot match by name + size are never hashed.
         /// </summary>
         public List<ReplicationFileInfo> GetManifest()

--- a/csharp/src/Replication/ReplicationDelta.cs
+++ b/csharp/src/Replication/ReplicationDelta.cs
@@ -60,7 +60,10 @@ namespace RocksDbSharp
 
         /// <summary>
         /// Scans the top level of a database directory for immutable files that
-        /// are candidates for reuse in a delta transfer.
+        /// are candidates for reuse in a delta transfer. Hashes are not
+        /// computed here: they are only worth computing for files whose name
+        /// and size match on both sides, so callers verify candidates through
+        /// a hash-request exchange (<see cref="ComputeFileHash"/>) afterwards.
         /// </summary>
         public static List<ReplicationFileInfo> ScanImmutableFiles(string directory)
         {
@@ -74,15 +77,37 @@ namespace RocksDbSharp
                 {
                     FileName = info.Name,
                     Size = info.Length,
-                    Hash = ComputeFileHash(filePath),
+                    Hash = string.Empty,
                 });
             }
             return result;
         }
 
         /// <summary>
+        /// Hash-request helper for the source side: returns the hash of the
+        /// named file only when it exists in <paramref name="directory"/>, is
+        /// an immutable file, and matches <paramref name="expectedSize"/> -
+        /// otherwise null, without computing anything. Immutability is what
+        /// makes hashing the live file (rather than a checkpoint copy) valid.
+        /// </summary>
+        public static string TryHashCandidate(string directory, string fileName, long expectedSize)
+        {
+            if (string.IsNullOrEmpty(fileName) || Path.GetFileName(fileName) != fileName) return null;
+            if (!IsImmutableFile(fileName)) return null;
+            var path = Path.Combine(directory, fileName);
+            var info = new FileInfo(path);
+            if (!info.Exists || info.Length != expectedSize) return null;
+            return ComputeFileHash(path);
+        }
+
+        /// <summary>
         /// Splits the source manifest into files the consumer can keep and
-        /// files that must be transferred.
+        /// files that must be transferred. Reuse requires a name + size match
+        /// and, when both sides supply a content hash, agreeing hashes. When
+        /// hashes are omitted the consumer must only list files it has already
+        /// verified through the hash-request exchange: name + size alone do
+        /// not imply equal content, because two RocksDB instances allocate
+        /// file numbers independently once they stop sharing a lineage.
         /// </summary>
         public static ReplicationDeltaPlan Compute(
             IEnumerable<ReplicationFileInfo> sourceManifest,
@@ -103,8 +128,9 @@ namespace RocksDbSharp
                 bool reusable = IsImmutableFile(src.FileName)
                                 && byName.TryGetValue(src.FileName, out var local)
                                 && local.Size == src.Size
-                                && !string.IsNullOrEmpty(src.Hash)
-                                && string.Equals(local.Hash, src.Hash, StringComparison.OrdinalIgnoreCase);
+                                && (string.IsNullOrEmpty(src.Hash)
+                                    || string.IsNullOrEmpty(local.Hash)
+                                    || string.Equals(local.Hash, src.Hash, StringComparison.OrdinalIgnoreCase));
                 if (reusable) plan.FilesToReuse.Add(src.FileName);
                 else plan.FilesToTransfer.Add(src.FileName);
             }

--- a/csharp/src/Replication/ReplicationDelta.cs
+++ b/csharp/src/Replication/ReplicationDelta.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace RocksDbSharp
 {
@@ -13,7 +15,7 @@ namespace RocksDbSharp
     {
         public string FileName { get; set; }
         public long Size { get; set; }
-        /// <summary>Identity signature (see <see cref="ReplicationDelta.ComputeFileSignature"/>). Empty for files that are never reused.</summary>
+        /// <summary>Identity signature (see <see cref="ReplicationDelta.ComputeFileSignatureAsync"/>). Empty for files that are never reused.</summary>
         public string Hash { get; set; }
     }
 
@@ -74,10 +76,15 @@ namespace RocksDbSharp
         /// whole-file hash inside the SST (blocks carry individual CRCs, which
         /// still guard reused files against corruption at read time).
         /// </summary>
-        public static string ComputeFileSignature(string path, int tailBytes = SignatureTailBytes)
+        public static async Task<string> ComputeFileSignatureAsync(
+            string path,
+            int tailBytes = SignatureTailBytes,
+            CancellationToken cancellationToken = default)
         {
             using (var sha = SHA256.Create())
-            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite,
+                                           bufferSize: 64 * 1024,
+                                           FileOptions.Asynchronous | FileOptions.SequentialScan))
             {
                 var header = BitConverter.GetBytes(fs.Length);
                 sha.TransformBlock(header, 0, header.Length, null, 0);
@@ -86,7 +93,7 @@ namespace RocksDbSharp
                 fs.Seek(start, SeekOrigin.Begin);
                 var buffer = new byte[64 * 1024];
                 int read;
-                while ((read = fs.Read(buffer, 0, buffer.Length)) > 0)
+                while ((read = await fs.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false)) > 0)
                 {
                     sha.TransformBlock(buffer, 0, read, null, 0);
                 }
@@ -100,7 +107,7 @@ namespace RocksDbSharp
         /// are candidates for reuse in a delta transfer. Hashes are not
         /// computed here: they are only worth computing for files whose name
         /// and size match on both sides, so callers verify candidates through
-        /// a hash-request exchange (<see cref="ComputeFileSignature"/>) afterwards.
+        /// a hash-request exchange (<see cref="ComputeFileSignatureAsync"/>) afterwards.
         /// </summary>
         public static List<ReplicationFileInfo> ScanImmutableFiles(string directory)
         {
@@ -127,14 +134,15 @@ namespace RocksDbSharp
         /// otherwise null, without computing anything. Immutability is what
         /// makes hashing the live file (rather than a checkpoint copy) valid.
         /// </summary>
-        public static string TryHashCandidate(string directory, string fileName, long expectedSize)
+        public static async Task<string> TryHashCandidateAsync(
+            string directory, string fileName, long expectedSize, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(fileName) || Path.GetFileName(fileName) != fileName) return null;
             if (!IsImmutableFile(fileName)) return null;
             var path = Path.Combine(directory, fileName);
             var info = new FileInfo(path);
             if (!info.Exists || info.Length != expectedSize) return null;
-            return ComputeFileSignature(path);
+            return await ComputeFileSignatureAsync(path, SignatureTailBytes, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/csharp/src/Replication/ReplicationDelta.cs
+++ b/csharp/src/Replication/ReplicationDelta.cs
@@ -13,7 +13,7 @@ namespace RocksDbSharp
     {
         public string FileName { get; set; }
         public long Size { get; set; }
-        /// <summary>SHA-256 of the file content (hex). Empty for files that are never reused.</summary>
+        /// <summary>Identity signature (see <see cref="ReplicationDelta.ComputeFileSignature"/>). Empty for files that are never reused.</summary>
         public string Hash { get; set; }
     }
 
@@ -37,24 +37,61 @@ namespace RocksDbSharp
     ///
     /// Granularity is whole files: a changed file is re-transferred in full,
     /// there is no content-level patching. Only immutable files (.sst / .blob)
-    /// are ever reused. Matching requires name + size + SHA-256, because two
-    /// RocksDB instances allocate file numbers independently once they stop
-    /// sharing a lineage - files with equal names (and even equal sizes) on
-    /// different nodes are not guaranteed to hold the same content.
+    /// are ever reused. Matching requires name + size + identity signature,
+    /// because two RocksDB instances allocate file numbers independently once
+    /// they stop sharing a lineage - files with equal names (and even equal
+    /// sizes) on different nodes are not guaranteed to hold the same content.
     /// </summary>
     public static class ReplicationDelta
     {
+        /// <summary>
+        /// How much of the end of a file the signature covers. The tail of an
+        /// SST holds the footer, the (top-level) index and the properties
+        /// block - which embeds RocksDB's own identity material: the creating
+        /// DB's UUID, the DB session identity (unique per instance run), the
+        /// original file number and the creation timestamps. Two SSTs from
+        /// different creation events therefore always differ inside this
+        /// window, while byte-copies are identical everywhere. 1 MiB leaves
+        /// ample margin for the index/metaindex blocks of large files.
+        /// </summary>
+        public const int SignatureTailBytes = 1024 * 1024;
+
         public static bool IsImmutableFile(string fileName) =>
             fileName.EndsWith(".sst", StringComparison.OrdinalIgnoreCase) ||
             fileName.EndsWith(".blob", StringComparison.OrdinalIgnoreCase);
 
-        public static string ComputeFileHash(string path)
+        /// <summary>
+        /// Identity signature of an immutable file: SHA-256 over the file
+        /// length and the last <paramref name="tailBytes"/> bytes.
+        ///
+        /// Hashing the *head* instead would not be safe: a replica's locally
+        /// flushed SST can carry a byte-identical data prefix (same keys,
+        /// values and sequence numbers ingested from the WAL stream) and only
+        /// differ near the end, where the identity properties live. Hashing
+        /// the tail compares exactly that identity material - it is the same
+        /// discriminator RocksDB's "unique SST id" is built from - without
+        /// reading multi-gigabyte files in full. RocksDB itself stores no
+        /// whole-file hash inside the SST (blocks carry individual CRCs, which
+        /// still guard reused files against corruption at read time).
+        /// </summary>
+        public static string ComputeFileSignature(string path, int tailBytes = SignatureTailBytes)
         {
             using (var sha = SHA256.Create())
             using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
-                var hash = sha.ComputeHash(fs);
-                return BitConverter.ToString(hash).Replace("-", string.Empty);
+                var header = BitConverter.GetBytes(fs.Length);
+                sha.TransformBlock(header, 0, header.Length, null, 0);
+
+                long start = Math.Max(0, fs.Length - tailBytes);
+                fs.Seek(start, SeekOrigin.Begin);
+                var buffer = new byte[64 * 1024];
+                int read;
+                while ((read = fs.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    sha.TransformBlock(buffer, 0, read, null, 0);
+                }
+                sha.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                return BitConverter.ToString(sha.Hash).Replace("-", string.Empty);
             }
         }
 
@@ -63,7 +100,7 @@ namespace RocksDbSharp
         /// are candidates for reuse in a delta transfer. Hashes are not
         /// computed here: they are only worth computing for files whose name
         /// and size match on both sides, so callers verify candidates through
-        /// a hash-request exchange (<see cref="ComputeFileHash"/>) afterwards.
+        /// a hash-request exchange (<see cref="ComputeFileSignature"/>) afterwards.
         /// </summary>
         public static List<ReplicationFileInfo> ScanImmutableFiles(string directory)
         {
@@ -97,7 +134,7 @@ namespace RocksDbSharp
             var path = Path.Combine(directory, fileName);
             var info = new FileInfo(path);
             if (!info.Exists || info.Length != expectedSize) return null;
-            return ComputeFileHash(path);
+            return ComputeFileSignature(path);
         }
 
         /// <summary>

--- a/csharp/src/Replication/ReplicationDelta.cs
+++ b/csharp/src/Replication/ReplicationDelta.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace RocksDbSharp
+{
+    /// <summary>
+    /// Inventory entry describing one database file on either side of a
+    /// snapshot transfer.
+    /// </summary>
+    public class ReplicationFileInfo
+    {
+        public string FileName { get; set; }
+        public long Size { get; set; }
+        /// <summary>SHA-256 of the file content (hex). Empty for files that are never reused.</summary>
+        public string Hash { get; set; }
+    }
+
+    /// <summary>
+    /// Result of comparing a source checkpoint manifest against a consumer's
+    /// local inventory.
+    /// </summary>
+    public class ReplicationDeltaPlan
+    {
+        /// <summary>Files the consumer already holds byte-identically; not transferred.</summary>
+        public List<string> FilesToReuse { get; } = new List<string>();
+        /// <summary>Files that are new or changed and must be transferred in full.</summary>
+        public List<string> FilesToTransfer { get; } = new List<string>();
+    }
+
+    /// <summary>
+    /// Per-file delta computation for snapshot transfers: a consumer offers an
+    /// inventory of its local immutable files, the source compares it against
+    /// its checkpoint and only streams the files that are new or changed; the
+    /// consumer deletes everything else before restoring.
+    ///
+    /// Granularity is whole files: a changed file is re-transferred in full,
+    /// there is no content-level patching. Only immutable files (.sst / .blob)
+    /// are ever reused. Matching requires name + size + SHA-256, because two
+    /// RocksDB instances allocate file numbers independently once they stop
+    /// sharing a lineage - files with equal names (and even equal sizes) on
+    /// different nodes are not guaranteed to hold the same content.
+    /// </summary>
+    public static class ReplicationDelta
+    {
+        public static bool IsImmutableFile(string fileName) =>
+            fileName.EndsWith(".sst", StringComparison.OrdinalIgnoreCase) ||
+            fileName.EndsWith(".blob", StringComparison.OrdinalIgnoreCase);
+
+        public static string ComputeFileHash(string path)
+        {
+            using (var sha = SHA256.Create())
+            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            {
+                var hash = sha.ComputeHash(fs);
+                return BitConverter.ToString(hash).Replace("-", string.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Scans the top level of a database directory for immutable files that
+        /// are candidates for reuse in a delta transfer.
+        /// </summary>
+        public static List<ReplicationFileInfo> ScanImmutableFiles(string directory)
+        {
+            var result = new List<ReplicationFileInfo>();
+            if (!Directory.Exists(directory)) return result;
+            foreach (var filePath in Directory.GetFiles(directory))
+            {
+                var info = new FileInfo(filePath);
+                if (!IsImmutableFile(info.Name)) continue;
+                result.Add(new ReplicationFileInfo
+                {
+                    FileName = info.Name,
+                    Size = info.Length,
+                    Hash = ComputeFileHash(filePath),
+                });
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Splits the source manifest into files the consumer can keep and
+        /// files that must be transferred.
+        /// </summary>
+        public static ReplicationDeltaPlan Compute(
+            IEnumerable<ReplicationFileInfo> sourceManifest,
+            IEnumerable<ReplicationFileInfo> consumerInventory)
+        {
+            var byName = new Dictionary<string, ReplicationFileInfo>(StringComparer.Ordinal);
+            if (consumerInventory != null)
+            {
+                foreach (var f in consumerInventory)
+                {
+                    if (f?.FileName != null) byName[f.FileName] = f;
+                }
+            }
+
+            var plan = new ReplicationDeltaPlan();
+            foreach (var src in sourceManifest)
+            {
+                bool reusable = IsImmutableFile(src.FileName)
+                                && byName.TryGetValue(src.FileName, out var local)
+                                && local.Size == src.Size
+                                && !string.IsNullOrEmpty(src.Hash)
+                                && string.Equals(local.Hash, src.Hash, StringComparison.OrdinalIgnoreCase);
+                if (reusable) plan.FilesToReuse.Add(src.FileName);
+                else plan.FilesToTransfer.Add(src.FileName);
+            }
+            return plan;
+        }
+
+        /// <summary>
+        /// Brings a database directory into the state the restore expects:
+        /// every subdirectory (most importantly the WAL/journal directory) and
+        /// every top-level file that is not reused is deleted, so files absent
+        /// from the source - stale SSTs, the old MANIFEST/CURRENT, divergent
+        /// WAL segments - cannot leak into the restored database. Entries
+        /// named in <paramref name="preserveNames"/> are kept regardless.
+        /// </summary>
+        public static void PrepareForRestore(string dbPath, ICollection<string> filesToReuse, ICollection<string> preserveNames)
+        {
+            var keep = new HashSet<string>(filesToReuse ?? (ICollection<string>)Array.Empty<string>(), StringComparer.Ordinal);
+            var preserve = new HashSet<string>(preserveNames ?? (ICollection<string>)Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var dir in Directory.GetDirectories(dbPath))
+            {
+                if (preserve.Contains(Path.GetFileName(dir))) continue;
+                Directory.Delete(dir, true);
+            }
+            foreach (var file in Directory.GetFiles(dbPath))
+            {
+                var name = Path.GetFileName(file);
+                if (preserve.Contains(name) || keep.Contains(name)) continue;
+                File.Delete(file);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Layered on the WAL-streaming + checkpoint snapshot primitives, this introduces
a transport-agnostic Raft orchestrator (RaftClusterNode) plus a new ClusterTest
console project that wires it together with MagicOnion gRPC.

Library additions (csharp/src/Cluster):
- RaftRole, ClusterMode, ClusterMember, RaftConfig: cluster topology and role state.
- RaftPersistentState + RaftLogTerms: crash-safe (currentTerm, votedFor, mode) +
  (seqNo -> term) range log written through atomic temp-file rename.
- PeerState: per-follower match/next sequence numbers and reachability.
- ElectionTimer: randomized election timeout (1.5-3s) reset by heartbeats.
- RaftClusterNode: RequestVote / AppendEntries handling, leader heartbeat loop,
  quorum commit advancement, bootstrap-to-cluster mode promotion, and
  IPeerTransport for outgoing RPCs (kept independent of gRPC).
- ClusterEvents: LeaderChanged / RoleChanged / ModeChanged.

Console project (Tests/ClusterTest):
- IClusterService: MagicOnion gRPC contract with RequestVote, Heartbeat, Join,
  GetStatus, SyncInitialState (snapshot), SyncUpdates (WAL stream), and a Write
  test helper. WAL batches carry the leader's term/id so followers can update
  their term log on the fly.
- ClusterService + ClusterNodeHost: hosts RocksDB, RaftClusterNode, MagicOnion
  Kestrel server, and the follower WAL streaming task that auto-reconnects on
  leader changes. Non-bootstrap nodes snapshot-sync from the bootstrap primary
  on first start.
- ClusterPeerTransport: MagicOnion-backed implementation of IPeerTransport.
- Program.cs coordinator with crash / hang / rejoin / election scenarios using
  Process.Kill (crash), SIGSTOP+SIGCONT (hang), and process restart (rejoin).

Initialization model: the bootstrap primary keeps serving writes in
ClusterMode.Bootstrap. Followers ingest the initial snapshot, stream the WAL,
and report their progress; once enough followers are within the configured lag
threshold, the primary promotes the cluster to ClusterMode.Cluster, after which
normal Raft elections kick in and any failure triggers a quorum-based
re-election.