### PR TITLE
Build the Linux glibc libraries on a compiler that can compile rocksdb

### DIFF
--- a/build-native/README.md
+++ b/build-native/README.md
@@ -54,6 +54,13 @@ Defaults to the architecture and libc of the machine it runs on. Requires
 `make`, `cmake`, a C++ toolchain, `git`, `curl`, and `libjemalloc-dev` for the
 jemalloc flavour.
 
+RocksDB has been a C++20 codebase since version 10 and does not build with
+anything older than GCC 11 or Clang 13 — `db.h` uses `using enum` and the
+block-based table builder includes `<semaphore>`. The script compiles a small
+probe with those two features before it starts, so an old compiler is reported
+as such instead of burying the build in template errors several hundred files
+in.
+
 For `linux-x64`/glibc it produces two libraries:
 
 * `librocksdb.so`
@@ -83,8 +90,8 @@ depend on jemalloc itself.
 Cross compiling to `arm64` needs `g++-aarch64-linux-gnu` on `PATH`.
 
 CI does not call the script directly, it goes through the container wrapper, so
-that the glibc and musl versions the artifacts are built against are pinned here
-instead of being inherited from the agent image:
+that the toolchain and the glibc and musl versions the artifacts are built
+against are pinned here instead of being inherited from the agent image:
 
 ```
 ./build-rocksdb-linux-docker.sh --arch x64   --libc glibc
@@ -95,6 +102,38 @@ instead of being inherited from the agent image:
 
 The last of those runs emulated under qemu, because no musl cross toolchain is
 packaged for Alpine, and takes considerably longer than the others.
+
+### How old a glibc the libraries load on
+
+The glibc builds happen in `ubuntu:22.04`, and the published libraries load on
+**glibc 2.34 and newer** — RHEL/Alma/Rocky 9, Amazon Linux 2023, Ubuntu 22.04,
+Debian 12, SLES 15 SP6 and everything released since.
+
+Those two versions being different is the point. What a library requires is the
+highest symbol version it references, not the glibc it was compiled against:
+glibc only stamps a new version onto a symbol when that symbol's behaviour
+changes, so the great majority of any build still resolves against far older
+releases. 2.34 is where it stops here, because that is where `libpthread` and
+`libdl` were folded into `libc` and everything they exported was reversioned.
+
+Jammy is the oldest image that gets there:
+
+* Bullseye, which these builds used until RocksDB moved to C++20, stops at GCC
+  10 and can no longer compile RocksDB at all.
+* Bookworm can, but its libstdc++ calls `arc4random` for `std::random_device`.
+  That symbol was added in glibc 2.36, and `-static-libstdc++` links that code
+  into the library, so building there would quietly cost us RHEL 9 and Amazon
+  Linux 2023. Jammy's glibc has no `arc4random` for its libstdc++ to find, so
+  the same code reads `/dev/urandom` instead.
+
+`verify_glibc_floor` in `common.sh` checks this after every glibc build and
+fails with the offending symbols listed. The floor is therefore a property the
+build enforces rather than one inferred from the base image, and moving it is a
+deliberate edit of `GLIBC_FLOOR` in `build-rocksdb-linux.sh` rather than a side
+effect of bumping a container tag.
+
+musl versions no symbols and ships one library per release, so there is no
+equivalent check for the musl flavour.
 
 ## macOS
 

--- a/build-native/build-rocksdb-linux-docker.sh
+++ b/build-native/build-rocksdb-linux-docker.sh
@@ -5,15 +5,17 @@
 #
 # Usage: ./build-rocksdb-linux-docker.sh --arch x64|arm64 --libc glibc|musl
 #
-#   x64   / glibc  debian, native speed
+#   x64   / glibc  ubuntu, native speed
 #   x64   / musl   alpine, native speed
-#   arm64 / glibc  debian + the aarch64-linux-gnu cross toolchain, native speed
+#   arm64 / glibc  ubuntu + the aarch64-linux-gnu cross toolchain, native speed
 #   arm64 / musl   arm64 alpine through qemu-user-static; this one is emulated
 #                  and takes several times as long as the others
 #
-# Building in a container rather than on the agent directly pins the glibc and
-# musl versions the artifacts are built against, which is what decides how old a
-# distribution they still load on.
+# Building in a container rather than on the agent directly pins the toolchain
+# and the glibc/musl versions the artifacts are built against, which is what
+# decides how old a distribution they still load on. build-rocksdb-linux.sh
+# checks the result against the floor the package promises, so a change of image
+# here cannot quietly raise it.
 #
 # The build tree and the resulting build-native/runtimes tree are shared with
 # the host through a bind mount, so the output lands in the same place as a
@@ -31,7 +33,7 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --arch) TARGET_ARCH="${2:-}"; shift 2 ;;
         --libc) TARGET_LIBC="${2:-}"; shift 2 ;;
-        -h|--help) sed -n '2,17p' "$0"; exit 0 ;;
+        -h|--help) sed -n '2,19p' "$0"; exit 0 ;;
         *) >&2 echo "unknown argument: $1"; exit 1 ;;
     esac
 done
@@ -47,8 +49,18 @@ EXTRA_ARGS=""
 
 case "${TARGET_ARCH}/${TARGET_LIBC}" in
     x64/glibc)
-        # bullseye keeps the glibc floor of the artifact at 2.31.
-        IMAGE="debian:bullseye"
+        # Jammy is the oldest distribution that can build rocksdb and still
+        # leave the artifact at the glibc 2.34 floor (see verify_glibc_floor):
+        #
+        #   * rocksdb is C++20 and needs gcc 11, where debian bullseye, the
+        #     previous image here, stops at gcc 10.
+        #   * the next candidate up, bookworm, ships a libstdc++ that calls
+        #     arc4random for std::random_device. That symbol arrived in glibc
+        #     2.36, and since -static-libstdc++ links that code into the
+        #     library, building there would raise the floor to 2.36 and drop
+        #     RHEL 9 and Amazon Linux 2023. Jammy's glibc 2.35 does not have
+        #     arc4random, so its libstdc++ uses /dev/urandom instead.
+        IMAGE="ubuntu:22.04"
         SETUP="apt-get update && apt-get install -y --no-install-recommends \
                    build-essential cmake git curl ca-certificates perl \
                    libjemalloc-dev"
@@ -58,9 +70,10 @@ case "${TARGET_ARCH}/${TARGET_LIBC}" in
         SETUP="apk add --no-cache bash make cmake g++ git curl perl tar coreutils findutils linux-headers"
         ;;
     arm64/glibc)
-        # Cross compiled rather than emulated. bullseye keeps the glibc floor of
-        # the artifact at 2.31.
-        IMAGE="debian:bullseye"
+        # Cross compiled rather than emulated, from the same image as x64/glibc
+        # so that both architectures are built by the same compiler against the
+        # same glibc.
+        IMAGE="ubuntu:22.04"
         SETUP="apt-get update && apt-get install -y --no-install-recommends \
                    build-essential cmake git curl ca-certificates perl \
                    g++-aarch64-linux-gnu"

--- a/build-native/build-rocksdb-linux.sh
+++ b/build-native/build-rocksdb-linux.sh
@@ -19,6 +19,9 @@
 # runtime. Build the musl flavour by running this script inside an Alpine
 # container; build linux-arm64 either on an arm64 machine or on x64 with the
 # aarch64-linux-gnu cross toolchain installed.
+#
+# rocksdb is C++20 and needs gcc 11 or newer, so the compiler has to be at least
+# as new as the one in Ubuntu 22.04 or Alpine 3.16.
 
 set -u
 
@@ -33,7 +36,7 @@ while [ $# -gt 0 ]; do
         --arch) TARGET_ARCH="${2:-}"; shift 2 ;;
         --libc) TARGET_LIBC="${2:-}"; shift 2 ;;
         --no-jemalloc) WITH_JEMALLOC=no; shift ;;
-        -h|--help) sed -n '2,22p' "$0"; exit 0 ;;
+        -h|--help) sed -n '2,25p' "$0"; exit 0 ;;
         *) fail "unknown argument: $1" ;;
     esac
 done
@@ -115,6 +118,8 @@ for tool in make git curl cmake "${CXX:-g++}"; do
     command -v "$tool" > /dev/null 2>&1 || fail "Build requires ${tool}"
 done
 
+require_cxx20 "${CXX:-g++}"
+
 # ---------------------------------------------------------------------------
 # Sources and dependencies
 # ---------------------------------------------------------------------------
@@ -131,6 +136,12 @@ export PORTABLE=1
 # when jemalloc is unavailable. The jemalloc flavour below opts back in
 # explicitly.
 export ROCKSDB_DISABLE_JEMALLOC=1
+
+# rocksdb builds with -Werror by default, and which warnings a compiler emits
+# for its sources is a property of that compiler rather than of this repository.
+# The macOS build already does this for the same reason; the Linux builds need
+# it too now that they follow rocksdb onto newer compilers.
+export DISABLE_WARNING_AS_ERROR=1
 
 build_static_compression_libs "$CONCURRENCY"
 
@@ -175,7 +186,7 @@ build_shared_lib() {
             ${extra_make_vars} || fail "${label} build failed"
 
         "$STRIP" librocksdb.so || warn "unable to strip ${label}"
-    }) || fail "${label} build failed"
+    }) || exit 1
 }
 
 # The C runtime, and nothing else. A compression library or libstdc++ turning
@@ -184,6 +195,19 @@ build_shared_lib() {
 BASE_DEPENDENCIES="libc.so.6 libm.so.6 libdl.so.2 librt.so.1 libpthread.so.0 libgcc_s.so.1
                    ld-linux-x86-64.so.2 ld-linux-aarch64.so.1
                    libc.musl-x86_64.so.1 libc.musl-aarch64.so.1"
+
+# The oldest glibc the published libraries are meant to load on, which is what
+# decides the distributions this package supports. 2.34 is where glibc folded
+# libpthread and libdl into libc and reversioned everything they exported, and
+# rocksdb uses enough of both that no build against a glibc that new can come
+# out below it. It covers RHEL/Alma/Rocky 9, Amazon Linux 2023, Ubuntu 22.04,
+# Debian 12 and everything since.
+#
+# The build image is newer than that (see build-rocksdb-linux-docker.sh),
+# because rocksdb needs a C++20 compiler and the distributions that still have a
+# 2.31-era glibc do not have one. verify_glibc_floor is what keeps the gap
+# between the two honest.
+GLIBC_FLOOR="2.34"
 
 # Checks the library just built, before it is published under its final name.
 check_library() {
@@ -195,6 +219,13 @@ check_library() {
     verify_library "${ROCKSDB_SRC_DIR}/librocksdb.so" $COMPRESSION_SYMBOLS "$@"
     verify_dependencies "${ROCKSDB_SRC_DIR}/librocksdb.so" "${CROSS_PREFIX}readelf" \
         $BASE_DEPENDENCIES
+
+    # musl does not version its symbols, and ships one library for every
+    # release, so there is no equivalent floor to check there.
+    if [ "$TARGET_LIBC" = "glibc" ]; then
+        verify_glibc_floor "${ROCKSDB_SRC_DIR}/librocksdb.so" "${CROSS_PREFIX}readelf" \
+            "$GLIBC_FLOOR"
+    fi
 }
 
 if [ "$TARGET_LIBC" = "musl" ]; then
@@ -250,6 +281,9 @@ if [ "$TARGET_LIBC" = "glibc" ] && [ "$WITH_JEMALLOC" = "yes" ]; then
     # Unlike the plain library, this one is expected to need libjemalloc.
     verify_dependencies "${ROCKSDB_SRC_DIR}/librocksdb.so" "${CROSS_PREFIX}readelf" \
         libjemalloc.so.2 $BASE_DEPENDENCIES
+
+    verify_glibc_floor "${ROCKSDB_SRC_DIR}/librocksdb.so" "${CROSS_PREFIX}readelf" \
+        "$GLIBC_FLOOR"
 
     "${CROSS_PREFIX}readelf" -d "${ROCKSDB_SRC_DIR}/librocksdb.so" \
         | grep -q "libjemalloc" \

--- a/build-native/build-rocksdb-macos.sh
+++ b/build-native/build-rocksdb-macos.sh
@@ -47,6 +47,8 @@ HOST_ARCH="$(uname -m)"
 command -v clang++ > /dev/null 2>&1 || fail "Build requires the Xcode command line tools"
 command -v lipo > /dev/null 2>&1 || fail "Build requires lipo (Xcode command line tools)"
 
+require_cxx20 clang++
+
 info "building rocksdb ${ROCKSDBVERSION} for [${ARCHES}] on ${HOST_ARCH} with ${CONCURRENCY} jobs"
 
 checkout_rocksdb

--- a/build-native/common.sh
+++ b/build-native/common.sh
@@ -53,6 +53,35 @@ detect_concurrency() {
     fi
 }
 
+# Fail unless the given C++ compiler can build the language and library features
+# rocksdb relies on.
+#
+# rocksdb has been a C++20 codebase since version 10: db.h reaches for `using
+# enum` and block_based_table_builder.cc includes <semaphore>, so anything older
+# than gcc 11 or clang 13 stops a few hundred files into the build with pages of
+# errors that say nothing about the actual problem. Upstream states the same
+# requirement in INSTALL.md ("GCC >= 11, Clang >= 10").
+require_cxx20() {
+    local cxx="$1"
+
+    if ! "$cxx" -std=c++20 -x c++ -fsyntax-only - > /dev/null 2>&1 <<'EOF'
+#include <semaphore>
+enum class Flags { None };
+int probe() {
+    using enum Flags;
+    std::counting_semaphore<1> gate{1};
+    gate.acquire();
+    return static_cast<int>(None);
+}
+EOF
+    then
+        fail "${cxx} cannot compile rocksdb ${ROCKSDBVERSION}, which is C++20 and needs at least gcc 11 or clang 13:
+    $("$cxx" --version 2>&1 | head -1)"
+    fi
+
+    info "$("$cxx" --version 2>&1 | head -1) builds C++20"
+}
+
 # Shallow-fetch a single ref into the current directory.
 checkout() {
     local name="$1"
@@ -284,6 +313,47 @@ verify_dependencies() {
     test -z "$foreign" || fail "${lib} depends on${foreign}, which will not be present on every machine"
 
     info "$(basename "$lib") only needs $(echo $needed)"
+}
+
+# True when the first version number is newer than the second.
+newer_version() {
+    test "$1" != "$2" && test "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$2"
+}
+
+# Fail if the library would need a newer glibc than the given floor.
+#
+# Which glibc an artifact requires is decided by the highest symbol version it
+# ended up referencing, not by the glibc it happened to be built against: glibc
+# only stamps a new version onto a symbol when that symbol's behaviour changes,
+# so the great majority of any build still resolves against far older releases.
+# The build image can therefore be much newer than the oldest distribution the
+# result loads on -- but only as long as somebody checks, which is what this is
+# for.
+verify_glibc_floor() {
+    local lib="$1"
+    local readelf="$2"
+    local floor="$3"
+
+    # Every glibc symbol carries its version as "name@GLIBC_x.y", or
+    # "name@@GLIBC_x.y" where it is the default version of a defined one.
+    local tagged
+    tagged="$("$readelf" --dyn-syms --wide "$lib" \
+        | awk 'index($8, "@GLIBC_") { print $8 }' | sed 's/@@/@/' | sort -u)"
+
+    test -n "$tagged" || fail "${lib} references no versioned glibc symbol at all, which cannot be right"
+
+    local sym version highest="0" offenders=""
+
+    while IFS= read -r sym; do
+        version="${sym##*@GLIBC_}"
+        newer_version "$version" "$highest" && highest="$version"
+        newer_version "$version" "$floor" && offenders="${offenders}    ${sym}"$'\n'
+    done <<< "$tagged"
+
+    test -z "$offenders" || fail "$(basename "$lib") needs glibc ${highest}, past the ${floor} floor this package promises:
+${offenders%$'\n'}"
+
+    info "$(basename "$lib") loads on glibc ${highest} and newer"
 }
 
 # Copy a built library into build-native/runtimes/<rid>/native/<name>.


### PR DESCRIPTION
rocksdb has been a C++20 codebase since version 10 -- db.h uses `using enum`
and the block based table builder includes <semaphore> -- so debian bullseye's
gcc 10 cannot compile it, and both glibc jobs died a few hundred files in with
"expected nested-name-specifier before 'enum'".

Move those two jobs to ubuntu:22.04, whose gcc 11 can. Which distribution to
move to is not a free choice: it decides how old a glibc the published library
still loads on, and bullseye was picked for exactly that reason. What sets the
floor is not the glibc the build ran against but the highest symbol version the
result references, and the first image that compiles rocksdb at all already
lands on 2.34 -- the release that folded libpthread and libdl into libc and
reversioned everything they exported. Jammy leaves it there; bookworm, the next
candidate up, would push it to 2.36, because its libstdc++ calls arc4random for
std::random_device and -static-libstdc++ links that call into the library. That
one symbol costs RHEL 9 and Amazon Linux 2023, so jammy it is.

Rather than leave that reasoning as a comment nobody can check, verify_glibc_floor
now reads the versioned symbols back out of every glibc library that gets built
and fails, listing them, if any of them is newer than GLIBC_FLOOR. The floor is
now something the build enforces instead of something inferred from a container
tag.

Two smaller things the compiler bump brought with it:

  * require_cxx20 compiles a probe using both features before the build starts,
    so an old toolchain says so in one line instead of in pages of template
    errors.
  * The Linux builds no longer treat warnings as errors, which is how the macOS
    build has been set up all along: which warnings a compiler emits for
    rocksdb's sources is a property of the compiler, not of this repository.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mo9uGPuimkNPxaoeKduVAM