### PR TITLE
Cross compile bzip2 too, and read the vcpkg libraries from installed/

### DIFF
--- a/build-native/README.md
+++ b/build-native/README.md
@@ -87,7 +87,15 @@ Where jemalloc is absent, the library simply does not load and RocksDbSharp
 falls through to `librocksdb.so` — which is why the plain library must never
 depend on jemalloc itself.
 
-Cross compiling to `arm64` needs `g++-aarch64-linux-gnu` on `PATH`.
+Cross compiling to `arm64` needs `g++-aarch64-linux-gnu` on `PATH`. Exporting
+`CC` is not enough to carry that through to every dependency — bzip2's makefile
+assigns `CC=gcc` itself, and a makefile assignment beats the environment — so
+the compression libraries are built with `CC` named on `make`'s command line,
+where it becomes an override the nested makes inherit. `verify_archives_match_compiler`
+then checks each archive against the architecture the compiler actually targets,
+because otherwise a dependency that quietly built for the host is only noticed
+by the linker at the very end of the build, in a message that names neither the
+library nor the architecture.
 
 CI does not call the script directly, it goes through the container wrapper, so
 that the toolchain and the glibc and musl versions the artifacts are built

--- a/build-native/build-rocksdb-linux.sh
+++ b/build-native/build-rocksdb-linux.sh
@@ -145,6 +145,8 @@ export DISABLE_WARNING_AS_ERROR=1
 
 build_static_compression_libs "$CONCURRENCY"
 
+verify_archives_match_compiler "${CXX:-g++}" $COMPRESSION_LDFLAGS
+
 # Keep the archives out of reach of `make clean`, which deletes every *.a in
 # the tree, so the two library variants below can share one dependency build.
 DEPS_DIR="${BUILD_NATIVE_DIR}/deps/${RID}${LIBC_SUFFIX}"

--- a/build-native/build-rocksdb-windows.sh
+++ b/build-native/build-rocksdb-windows.sh
@@ -25,9 +25,16 @@ test -n "${WindowsSdkDir:-}" \
     || fail "This must be run from a build environment such as the Developer Command Prompt"
 
 # The hosted Windows images ship vcpkg pre-installed and point
-# VCPKG_INSTALLATION_ROOT at it.
+# VCPKG_INSTALLATION_ROOT at it, spelled with backslashes. Everything below
+# builds paths out of it that end up in CMake variables and in log lines, both
+# of which are happier with forward slashes; Windows itself accepts either.
 VCPKG_ROOT="${VCPKG_INSTALLATION_ROOT:-C:/vcpkg}"
-VCPKG_PACKAGES="${VCPKG_ROOT}/packages"
+VCPKG_ROOT="${VCPKG_ROOT//\\//}"
+
+# Where vcpkg puts the finished libraries. Not "packages/<port>_<triplet>",
+# which is scratch space vcpkg is free to clean out once it has installed from
+# it -- and does, which is why this build stopped finding zlib.lib there.
+VCPKG_INSTALLED="${VCPKG_ROOT}/installed/x64-windows-static"
 
 info "building rocksdb ${ROCKSDBVERSION} for win-x64 with ${CONCURRENCY} jobs"
 info "using vcpkg at ${VCPKG_ROOT}"
@@ -45,26 +52,41 @@ vcpkg.exe install \
     zstd:x64-windows-static \
     || fail "unable to install libraries with vcpkg.exe"
 
+# The debug counterpart of a release library, where vcpkg built one. Only
+# Release is ever built here, but rocksdb's thirdparty.inc wants both paths, and
+# the debug file names differ from port to port (zlibd.lib against snappy.lib),
+# so look rather than guess and fall back to the release library.
+debug_counterpart() {
+    local candidate="${VCPKG_INSTALLED}/debug/lib/$(basename "$1")"
+
+    if [ -f "$candidate" ]; then
+        echo "$candidate"
+    else
+        echo "$1"
+    fi
+}
+
 # rocksdb's thirdparty.inc reads these out of the environment; without them it
 # falls back to the long dead THIRDPARTY_HOME/*.Library layout.
-export ZLIB_INCLUDE="${VCPKG_PACKAGES}/zlib_x64-windows-static/include"
-export ZLIB_LIB_DEBUG="${VCPKG_PACKAGES}/zlib_x64-windows-static/debug/lib/zlib.lib"
-export ZLIB_LIB_RELEASE="${VCPKG_PACKAGES}/zlib_x64-windows-static/lib/zlib.lib"
+export ZLIB_INCLUDE="${VCPKG_INSTALLED}/include"
+export ZLIB_LIB_RELEASE="${VCPKG_INSTALLED}/lib/zlib.lib"
+export ZLIB_LIB_DEBUG="$(debug_counterpart "$ZLIB_LIB_RELEASE")"
 
-export LZ4_INCLUDE="${VCPKG_PACKAGES}/lz4_x64-windows-static/include"
-export LZ4_LIB_DEBUG="${VCPKG_PACKAGES}/lz4_x64-windows-static/debug/lib/lz4.lib"
-export LZ4_LIB_RELEASE="${VCPKG_PACKAGES}/lz4_x64-windows-static/lib/lz4.lib"
+export LZ4_INCLUDE="${VCPKG_INSTALLED}/include"
+export LZ4_LIB_RELEASE="${VCPKG_INSTALLED}/lib/lz4.lib"
+export LZ4_LIB_DEBUG="$(debug_counterpart "$LZ4_LIB_RELEASE")"
 
-export SNAPPY_INCLUDE="${VCPKG_PACKAGES}/snappy_x64-windows-static/include"
-export SNAPPY_LIB_DEBUG="${VCPKG_PACKAGES}/snappy_x64-windows-static/debug/lib/snappy.lib"
-export SNAPPY_LIB_RELEASE="${VCPKG_PACKAGES}/snappy_x64-windows-static/lib/snappy.lib"
+export SNAPPY_INCLUDE="${VCPKG_INSTALLED}/include"
+export SNAPPY_LIB_RELEASE="${VCPKG_INSTALLED}/lib/snappy.lib"
+export SNAPPY_LIB_DEBUG="$(debug_counterpart "$SNAPPY_LIB_RELEASE")"
 
-export ZSTD_INCLUDE="${VCPKG_PACKAGES}/zstd_x64-windows-static/include"
-export ZSTD_LIB_DEBUG="${VCPKG_PACKAGES}/zstd_x64-windows-static/debug/lib/zstd_d.lib"
-export ZSTD_LIB_RELEASE="${VCPKG_PACKAGES}/zstd_x64-windows-static/lib/zstd.lib"
+export ZSTD_INCLUDE="${VCPKG_INSTALLED}/include"
+export ZSTD_LIB_RELEASE="${VCPKG_INSTALLED}/lib/zstd.lib"
+export ZSTD_LIB_DEBUG="$(debug_counterpart "$ZSTD_LIB_RELEASE")"
 
 for lib in "$ZLIB_LIB_RELEASE" "$LZ4_LIB_RELEASE" "$SNAPPY_LIB_RELEASE" "$ZSTD_LIB_RELEASE"; do
-    test -f "$lib" || fail "vcpkg did not produce ${lib}"
+    test -f "$lib" || fail "vcpkg did not produce ${lib}, only:
+$(ls "${VCPKG_INSTALLED}/lib" 2>/dev/null | sed 's/^/    /')"
 done
 
 # ---------------------------------------------------------------------------

--- a/build-native/common.sh
+++ b/build-native/common.sh
@@ -27,17 +27,20 @@ RUNTIMES_DIR="${BUILD_NATIVE_DIR}/runtimes"
 ROCKSDBVNUM="$(cut -d. -f1-3 "${BUILD_NATIVE_DIR}/../rocksdbversion")"
 ROCKSDBVERSION="v${ROCKSDBVNUM}"
 
+# printf rather than `echo -e`, which would also expand any backslash escape
+# that happens to be in the message. Windows paths are full of them: a message
+# mentioning C:\vcpkg came out as "C:" followed by a vertical tab.
 fail() {
-    >&2 echo -e "\033[1;31m$1\033[0m"
+    >&2 printf '\033[1;31m%s\033[0m\n' "$1"
     exit 1
 }
 
 warn() {
-    >&2 echo -e "\033[1;33m$1\033[0m"
+    >&2 printf '\033[1;33m%s\033[0m\n' "$1"
 }
 
 info() {
-    echo -e "\033[1;34m==> $1\033[0m"
+    printf '\033[1;34m==> %s\033[0m\n' "$1"
 }
 
 # Number of parallel compile jobs, derived from the machine we are running on.
@@ -221,6 +224,18 @@ build_static_compression_libs() {
 
     prefetch_dependency_sources
 
+    # bzip2's own makefile assigns CC=gcc, and a makefile assignment beats the
+    # environment, so exporting CC is not enough to cross compile it: a build for
+    # arm64 quietly filled libbz2.a with host objects and only fell over much
+    # later, when the linker refused the archive. Naming CC on make's command
+    # line instead makes it an override, which the nested makes inherit through
+    # MAKEFLAGS and which does win over their own assignments.
+    #
+    # Left empty where CC is unset, which is every native build plus macOS, where
+    # the architecture travels in ARCHFLAG/CFLAGS instead.
+    local toolchain=""
+    test -z "${CC:-}" || toolchain="CC=${CC}"
+
     # Built one at a time: the individual targets unpack tarballs and shell out
     # to nested makes, which do not compose safely under a parallel outer make.
     #
@@ -230,11 +245,11 @@ build_static_compression_libs() {
     # own -O2 CFLAGS. Without it the warning shows up in the log of every build
     # and reads like the artifact is a debug build, which it is not.
     (cd "${ROCKSDB_SRC_DIR}" && {
-        make -j"${concurrency}" DEBUG_LEVEL=0 libz.a      || fail "zlib build failed"
-        make -j"${concurrency}" DEBUG_LEVEL=0 libbz2.a    || fail "bzip2 build failed"
-        make -j"${concurrency}" DEBUG_LEVEL=0 libsnappy.a || fail "snappy build failed"
-        make -j"${concurrency}" DEBUG_LEVEL=0 liblz4.a    || fail "lz4 build failed"
-        make -j"${concurrency}" DEBUG_LEVEL=0 libzstd.a   || fail "zstd build failed"
+        make -j"${concurrency}" DEBUG_LEVEL=0 $toolchain libz.a      || fail "zlib build failed"
+        make -j"${concurrency}" DEBUG_LEVEL=0 $toolchain libbz2.a    || fail "bzip2 build failed"
+        make -j"${concurrency}" DEBUG_LEVEL=0 $toolchain libsnappy.a || fail "snappy build failed"
+        make -j"${concurrency}" DEBUG_LEVEL=0 $toolchain liblz4.a    || fail "lz4 build failed"
+        make -j"${concurrency}" DEBUG_LEVEL=0 $toolchain libzstd.a   || fail "zstd build failed"
     }) || fail "compression library build failed"
 
     # Flags describing those archives to the rocksdb build. Mirrors upstream's
@@ -313,6 +328,43 @@ verify_dependencies() {
     test -z "$foreign" || fail "${lib} depends on${foreign}, which will not be present on every machine"
 
     info "$(basename "$lib") only needs $(echo $needed)"
+}
+
+# The architectures of the ELF objects in a file, one per line. An archive holds
+# a header per member, so anything but a single line means a mixed archive.
+elf_machines() {
+    readelf -h "$1" 2>/dev/null | sed -n 's/^ *Machine: *//p' | sort -u
+}
+
+# Fail unless every archive named holds objects for the architecture the given
+# compiler builds for. ELF only, so Linux; macOS checks the finished dylib with
+# lipo instead.
+#
+# A dependency that ignores the cross compiler and builds for the host produces
+# an archive that is perfectly valid and simply wrong, and nothing notices until
+# the link at the very end of the build reports "file in wrong format" without
+# naming an architecture. Comparing here costs a compile of one line.
+verify_archives_match_compiler() {
+    local cxx="$1"
+    shift
+
+    local probe expected archive machines
+    probe="$(mktemp -d)" || fail "unable to create a temporary directory"
+
+    echo 'int rocksdb_sharp_architecture_probe;' \
+        | "$cxx" -x c++ -c - -o "${probe}/probe.o" \
+        || fail "unable to compile an architecture probe with ${cxx}"
+
+    expected="$(elf_machines "${probe}/probe.o")"
+    rm -rf "$probe"
+
+    for archive in "$@"; do
+        machines="$(elf_machines "$archive")"
+        test "$machines" = "$expected" \
+            || fail "$(basename "$archive") holds ${machines:-unreadable} objects, but ${cxx} builds for ${expected}"
+    done
+
+    info "the static archives are ${expected}"
 }
 
 # True when the first version number is newer than the second.


### PR DESCRIPTION
Two things the previous round uncovered.

The arm64 build linked bzip2 objects built for x86-64: "Relocations in generic ELF (EM: 62)", EM 62 being the host. rocksdb's libbz2.a target hands the nested make CFLAGS and AR but not CC, and bzip2's own makefile assigns CC=gcc, which beats an exported CC. Every other dependency either takes CC from the environment or is a cmake project, which is why bzip2 was the only archive the linker refused. Naming CC on the outer make's command line makes it an override instead, and overrides reach nested makes through MAKEFLAGS and win there too.

An archive being built for the wrong architecture is not something the build should be finding out at the final link, in a message that names neither the library nor the architecture, so verify_archives_match_compiler now compares each archive against an object the compiler produces itself, right after the compression libraries are built.

On Windows, vcpkg had stopped leaving the libraries in packages/<port>_<triplet> by the time the build looked. That directory is scratch space vcpkg installs *from*; installed/<triplet> is the finished tree and is where these paths should have been pointing all along. The check now also lists what is in lib/ when it does not find what it wants.

The error that reported this said "C:cpkg", because fail/warn/info printed through `echo -e` and \v in C:\vcpkg is a vertical tab. They use printf with a %s now, so a message means what it says.


Claude-Session: https://claude.ai/code/session_01Mo9uGPuimkNPxaoeKduVAM