### PR TITLE
Keep git bash from rewriting cl.exe options into paths

### DIFF
--- a/build-native/README.md
+++ b/build-native/README.md
@@ -169,6 +169,13 @@ vcpkg is expected to be present; the hosted build images ship it and point
 `VCPKG_INSTALLATION_ROOT` at it. Set that variable yourself if your vcpkg lives
 somewhere other than `C:\vcpkg`.
 
+Compiler options are passed to CMake in their `-wd4267` form rather than the
+`/wd4267` one MSVC is usually given, because git bash rewrites any argument
+that looks like an absolute POSIX path into a Windows one — `/wd4267` arrived
+at `cl.exe` as `C:/Program Files/Git/wd4267`, which it tried to compile.
+Argument conversion is switched off for the CMake call as well; nothing in it
+needs converting.
+
 The libraries are read out of `installed/x64-windows-static`, vcpkg's finished
 tree, rather than out of `packages/<port>_<triplet>`, which is scratch space
 vcpkg is free to clean out once it has installed from it. Their file names are

--- a/build-native/build-rocksdb-windows.sh
+++ b/build-native/build-rocksdb-windows.sh
@@ -151,12 +151,32 @@ update_vcxproj() {
         #  USE_RTTI=1                   RTTI is off in MSVC release builds by
         #                               default; rocksdb's options machinery
         #                               uses dynamic_cast
+        #  FAIL_ON_WARNINGS=0           rocksdb defaults this on, which puts
+        #                               /W4 /WX on its own sources; which
+        #                               warnings a compiler emits for them is a
+        #                               property of the compiler, not of this
+        #                               repository. The Linux and macOS builds
+        #                               opt out the same way.
+        #  -wd4267                      size_t truncation warnings from
+        #                               rocksdb's sources, silenced to keep the
+        #                               build log readable rather than to keep
+        #                               it running
         # Tools, tests and benchmarks are all switched off: only rocksdb-shared
         # is built below.
+        #
+        # Compiler options are spelled with a leading dash, not the slash cl.exe
+        # is usually given (it accepts either), and argument conversion is off
+        # for this command. git bash rewrites any argument that looks like an
+        # absolute POSIX path into a Windows one: "/wd4267" reached cl.exe as
+        # "C:/Program Files/Git/wd4267", which it dutifully tried to compile.
+        # Nothing here needs converting -- the vcpkg paths are already in
+        # Windows form and everything else is relative.
+        MSYS2_ARG_CONV_EXCL='*' MSYS_NO_PATHCONV=1 \
         cmake -G "Visual Studio 17 2022" -A x64 \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_STANDARD=20 \
-            -DCMAKE_CXX_FLAGS="/wd4267" \
+            -DCMAKE_CXX_FLAGS="-wd4267" \
+            -DFAIL_ON_WARNINGS=0 \
             -DWITH_WINDOWS_UTF8_FILENAMES=1 \
             -DWITH_MD_LIBRARY=0 \
             -DPORTABLE=1 \


### PR DESCRIPTION
The Windows build passed CMAKE_CXX_FLAGS=/wd4267, and git bash rewrites any argument that looks like an absolute POSIX path into a Windows one, so cl.exe was handed C:/Program Files/Git/wd4267 as a source file and CMake concluded the compiler was broken before it compiled a line of rocksdb.

cl.exe takes its options with a dash as readily as with a slash, so the flag is spelled -wd4267 now, and argument conversion is switched off for the cmake call so the next option somebody adds cannot repeat this. Nothing in that command needs converting: the vcpkg paths are already in Windows form and the rest is relative.

While here, FAIL_ON_WARNINGS=0. rocksdb defaults it on, which builds its own sources under /W4 /WX -- the reason -wd4267 had to be there in the first place. Which warnings a compiler emits for rocksdb's code is a property of the compiler, and the Linux and macOS builds already opt out of the same thing; this leaves MSVC free to add a warning without breaking the release. -wd4267 stays, now only to keep the log readable.


Claude-Session: https://claude.ai/code/session_01Mo9uGPuimkNPxaoeKduVAM