### PR TITLE
Quote the paths the blob upload and download are given

### DIFF
--- a/.azure-devops/templates/download-native.yaml
+++ b/.azure-devops/templates/download-native.yaml
@@ -1,5 +1,9 @@
 # Downloads native libraries published by the build-native-* pipelines into
 # csharp/runtimes/<rid>/native/, replacing the placeholders checked into git.
+#
+# The paths are quoted for the same reason as in publish-native.yaml: bash eats
+# the backslashes in a Windows $(Build.SourcesDirectory) otherwise. This one only
+# ever runs on the Linux packing agent, but the two should not differ over that.
 parameters:
 - name: rid
   type: string
@@ -16,7 +20,7 @@ steps:
       scriptLocation: 'inlineScript'
       inlineScript: >
         az storage blob download
-        -f $(Build.SourcesDirectory)/csharp/runtimes/${{ parameters.rid }}/native/${{ file }}
+        -f "$(Build.SourcesDirectory)/csharp/runtimes/${{ parameters.rid }}/native/${{ file }}"
         --account-name curiosityreleases
         -c rocksdb
-        -n v$(ROCKSDBVERSIONBASE)/${{ parameters.rid }}/${{ file }}
+        -n "v$(ROCKSDBVERSIONBASE)/${{ parameters.rid }}/${{ file }}"

--- a/.azure-devops/templates/publish-native.yaml
+++ b/.azure-devops/templates/publish-native.yaml
@@ -1,5 +1,10 @@
 # Uploads native libraries built by build-native/ to blob storage, under
 # v<version>/<rid>/<file>, where build-nuget.yaml picks them up again.
+#
+# The paths are quoted because these scripts run under bash on every agent,
+# including the Windows one, where $(Build.SourcesDirectory) expands to
+# D:\a\1\s. Unquoted, bash reads each backslash as escaping the character after
+# it and az is handed D:a1s/build-native/... instead.
 parameters:
 - name: rid
   type: string
@@ -16,8 +21,8 @@ steps:
       scriptLocation: 'inlineScript'
       inlineScript: >
         az storage blob upload
-        -f $(Build.SourcesDirectory)/build-native/runtimes/${{ parameters.rid }}/native/${{ file }}
+        -f "$(Build.SourcesDirectory)/build-native/runtimes/${{ parameters.rid }}/native/${{ file }}"
         --account-name curiosityreleases
         -c rocksdb
-        -n v$(ROCKSDBVERSION)/${{ parameters.rid }}/${{ file }}
+        -n "v$(ROCKSDBVERSION)/${{ parameters.rid }}/${{ file }}"
         --overwrite true


### PR DESCRIPTION
These templates run as bash on every agent, the Windows one included, where $(Build.SourcesDirectory) expands to D:\a\1\s. The path was unquoted, so bash read each backslash as escaping the character after it and az was asked to upload D:a1s/build-native/runtimes/win-x64/native/rocksdb.dll. The Linux and macOS jobs never noticed, their paths having no backslashes to lose.

download-native.yaml only ever runs on the Linux packing agent, but it has the same shape and there is no reason for the two to differ over this.


Claude-Session: https://claude.ai/code/session_01Mo9uGPuimkNPxaoeKduVAM